### PR TITLE
chore(pages): add custom domain, robots.txt, and sitemap.xml

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - "source/ESPEED32/data/docs/**"
       - "source/ESPEED32/data/ui/**"
+      - "CNAME"
       - ".github/workflows/pages.yml"
   workflow_dispatch:
 
@@ -55,10 +56,56 @@ jobs:
           cp -R source/ESPEED32/data/ui/. site/ui/
           cp source/ESPEED32/data/ui/index.html site/index.html
 
+          SITE_URL=""
+
           # Optional custom domain: commit a CNAME file in repository root.
           if [ -f CNAME ]; then
+            SITE_HOST="$(tr -d '[:space:]' < CNAME)"
+            if [ -n "$SITE_HOST" ]; then
+              SITE_URL="https://$SITE_HOST"
+            fi
             cp CNAME site/CNAME
           fi
+
+          if [ -z "$SITE_URL" ]; then
+            REPO_NAME="${GITHUB_REPOSITORY#*/}"
+            SITE_URL="https://${GITHUB_REPOSITORY_OWNER}.github.io/${REPO_NAME}"
+          fi
+
+          TODAY="$(date -u +%F)"
+
+          cat > site/robots.txt << EOF
+          User-agent: *
+          Allow: /
+
+          Sitemap: ${SITE_URL}/sitemap.xml
+          EOF
+
+          cat > site/sitemap.xml << EOF
+          <?xml version="1.0" encoding="UTF-8"?>
+          <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+            <url>
+              <loc>${SITE_URL}/</loc>
+              <lastmod>${TODAY}</lastmod>
+            </url>
+            <url>
+              <loc>${SITE_URL}/docs/en/</loc>
+              <lastmod>${TODAY}</lastmod>
+            </url>
+            <url>
+              <loc>${SITE_URL}/docs/no/</loc>
+              <lastmod>${TODAY}</lastmod>
+            </url>
+            <url>
+              <loc>${SITE_URL}/docs/es/</loc>
+              <lastmod>${TODAY}</lastmod>
+            </url>
+            <url>
+              <loc>${SITE_URL}/docs/de/</loc>
+              <lastmod>${TODAY}</lastmod>
+            </url>
+          </urlset>
+          EOF
 
           touch site/.nojekyll
 

--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+espeed32.com


### PR DESCRIPTION
## Summary

Improve basic SEO support for the GitHub Pages site by adding custom domain support and generating crawler-friendly site metadata during the Pages build.

## Changes

- add a root `CNAME` file for `espeed32.com`
- generate `robots.txt` automatically in the Pages workflow
- generate `sitemap.xml` automatically in the Pages workflow
- make the workflow react to `CNAME` changes as well

## Why

The site is hosted on GitHub Pages, so the simplest SEO wins are to expose the correct canonical domain and provide standard discovery files for search engines.

This change helps search engines find and crawl:

- `/`
- `/docs/en/`
- `/docs/no/`
- `/docs/es/`
- `/docs/de/`

## Impact

No firmware behavior changes.

No controller-side UI logic changes.

This only affects the hosted Pages output and domain metadata.

## Verification

- verified that the workflow builds `robots.txt`
- verified that the workflow builds `sitemap.xml`
- verified that the generated sitemap is valid XML
- verified that `CNAME` resolves the site URL to `https://espeed32.com`
