### PR TITLE
ESPEED firmware v6.9.2

### DIFF
--- a/source/ESPEED32/data/ui/index.html
+++ b/source/ESPEED32/data/ui/index.html
@@ -1252,12 +1252,12 @@ form{margin:0}
 <option value="">Loading latest...</option>
 </select>
 </div>
-<p id="fw-release-note" class="tiny">Choose which standard official release automatic update should install. Both firmware and filesystem will be updated together.</p>
+<p id="fw-release-note" class="tiny">Choose which official release automatic update should install. Firmware variant is matched to this controller's HAL Sensor when release metadata provides one.</p>
 <p id="fw-release-source" class="tiny" style="display:none"></p>
 <button type="button" class="btn dl" id="btn-fw-auto" onclick="autoUpdateFirmware()">Install Selected Release</button>
 <p id="fw-auto-desc" class="tiny">Downloads the selected release pair, uploads firmware first and filesystem second, then reboots once at the end.</p>
 <p class="tiny">Recommended when you want a matched official release without downloading files manually.</p>
-<p class="tiny warn">Automatic update follows the standard official firmware path, which uses the default TLE493D build. If this controller reports another HAL Sensor, use Manual Update with the matching sensor-specific firmware file and the SPIFFS file from the same release.</p>
+<p class="tiny warn">Automatic update now tries to match firmware to this controller's HAL Sensor. If no matching firmware variant exists for the selected release, automatic firmware update is blocked and you must use Manual Update with the matching sensor-specific firmware file and the SPIFFS file from the same release.</p>
 </div>
 <p id="ota-note" style="display:none" class="warn"></p>
 <div id="auto-fw-progress" class="progress-wrap" aria-live="polite">
@@ -1624,6 +1624,17 @@ function renderControllerAbout(){
   }
 }
 
+function getControllerHalSensorFamily(){
+  var raw=String(info.halSensor||'').trim().toUpperCase();
+  if(!raw) return '';
+  if(raw.indexOf('TLE493D')===0) return 'TLE493D';
+  if(raw.indexOf('AS5600L')===0) return 'AS5600L';
+  if(raw.indexOf('AS5600')===0) return 'AS5600';
+  if(raw.indexOf('MT6701')===0) return 'MT6701';
+  if(raw.indexOf('ANALOG')===0) return 'ANALOG';
+  return raw.split(/\s+/)[0];
+}
+
 function ss(id,c,m){var e=document.getElementById(id);if(!e) return;e.className='st '+c;e.textContent=m;e.style.display='block';}
 function clearStatus(id){var e=document.getElementById(id);if(!e) return;e.className='st';e.textContent='';e.style.display='none';}
 function esc(s){return String(s==null?'':s).replace(/[&<>"']/g,function(ch){return({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'})[ch];});}
@@ -1784,6 +1795,32 @@ function formatSelectedReleaseLabel(entry){
   return formatReleaseVersionLabel(entry);
 }
 
+function normalizeFirmwareVariants(rawVariants,legacyFirmwareUrl,legacyFirmwareSha256Url){
+  var out={};
+  if(rawVariants && typeof rawVariants==='object'){
+    for(var key in rawVariants){
+      if(!Object.prototype.hasOwnProperty.call(rawVariants,key)) continue;
+      var family=String(key||'').trim().toUpperCase();
+      if(!family) continue;
+      var variant=rawVariants[key]||{};
+      var url=String(variant.url||'').trim();
+      if(!url) continue;
+      out[family]={
+        url:url,
+        sha256Url:String(variant.sha256Url||'').trim()
+      };
+    }
+  }
+  var legacyUrl=String(legacyFirmwareUrl||'').trim();
+  if(legacyUrl && !out.TLE493D){
+    out.TLE493D={
+      url:legacyUrl,
+      sha256Url:String(legacyFirmwareSha256Url||'').trim()
+    };
+  }
+  return out;
+}
+
 function normalizeReleaseEntry(item){
   if(!item) return null;
 
@@ -1802,13 +1839,6 @@ function normalizeReleaseEntry(item){
       :'https://github.com/nerdweeg/ESPEED32/releases/latest';
   }
 
-  var firmwareUrl=String(item.firmwareUrl||'').trim();
-  if(!firmwareUrl){
-    firmwareUrl=(version!=='latest')
-      ?('https://downloads.espeed32.com/releases/'+encodeURIComponent(version)+'/firmware.bin')
-      :AUTO_UPDATE_FIRMWARE_URL;
-  }
-
   var spiffsUrl=String(item.spiffsUrl||'').trim();
   if(!spiffsUrl){
     spiffsUrl=(version!=='latest')
@@ -1816,14 +1846,18 @@ function normalizeReleaseEntry(item){
       :AUTO_UPDATE_SPIFFS_URL;
   }
 
+  var spiffsSha256Url=String(item.spiffsSha256Url||'').trim();
+  var firmwareVariants=normalizeFirmwareVariants(item.firmwareVariants,item.firmwareUrl,item.firmwareSha256Url);
+
   return {
     version:version,
     tag:tag,
     name:String(item.name||'').trim(),
     publishedAt:String(item.publishedAt||'').trim(),
     source:source,
-    firmwareUrl:firmwareUrl,
     spiffsUrl:spiffsUrl,
+    spiffsSha256Url:spiffsSha256Url,
+    firmwareVariants:firmwareVariants,
     isLatest:false
   };
 }
@@ -1844,7 +1878,7 @@ function applyReleaseSelection(releases,latestVersion,preferredVersion){
 
   latestReleaseTag=latestEntry?String(latestEntry.tag||'').trim():'';
   latestReleaseUrl=latestEntry?String(latestEntry.source||'').trim():'';
-  latestFirmwareBinUrl=latestEntry?String(latestEntry.firmwareUrl||'').trim():'';
+  latestFirmwareBinUrl=latestEntry?String((((latestEntry.firmwareVariants||{}).TLE493D||{}).url)||'').trim():'';
   latestSpiffsBinUrl=latestEntry?String(latestEntry.spiffsUrl||'').trim():'';
 
   var wanted=normalizeReleaseVersionId(preferredVersion || selectedReleaseVersion);
@@ -1871,10 +1905,32 @@ function getSelectedReleaseMeta(){
   return availableReleases.length?availableReleases[0]:null;
 }
 
+function getMatchedFirmwareVariant(entry){
+  if(!entry || !entry.firmwareVariants || typeof entry.firmwareVariants!=='object') return null;
+  var family=getControllerHalSensorFamily();
+  if(family && entry.firmwareVariants[family] && entry.firmwareVariants[family].url){
+    return {
+      family:family,
+      url:String(entry.firmwareVariants[family].url||'').trim(),
+      sha256Url:String(entry.firmwareVariants[family].sha256Url||'').trim()
+    };
+  }
+  if(!family && entry.firmwareVariants.TLE493D && entry.firmwareVariants.TLE493D.url){
+    return {
+      family:'TLE493D',
+      url:String(entry.firmwareVariants.TLE493D.url||'').trim(),
+      sha256Url:String(entry.firmwareVariants.TLE493D.sha256Url||'').trim()
+    };
+  }
+  return null;
+}
+
 function getSelectedReleaseDownloadUrl(kind){
   var selected=getSelectedReleaseMeta();
   if(!selected) return '';
-  return kind==='spiffs'?String(selected.spiffsUrl||'').trim():String(selected.firmwareUrl||'').trim();
+  if(kind==='spiffs') return String(selected.spiffsUrl||'').trim();
+  var variant=getMatchedFirmwareVariant(selected);
+  return variant?variant.url:'';
 }
 
 function normalizeInstalledReleaseVersion(value){
@@ -2058,12 +2114,17 @@ function updateReleaseInfoUi(){
     list.className='release-list';
 
     var itemFw=document.createElement('li');
-    var dl=document.createElement('a');
-    dl.href=selected.firmwareUrl || AUTO_UPDATE_FIRMWARE_URL;
-    dl.target='_blank';
-    dl.rel='noopener';
-    dl.textContent='Download firmware '+formatSelectedReleaseLabel(selected)+' (.bin)';
-    itemFw.appendChild(dl);
+    var matchedFirmware=getMatchedFirmwareVariant(selected);
+    if(matchedFirmware && matchedFirmware.url){
+      var dl=document.createElement('a');
+      dl.href=matchedFirmware.url;
+      dl.target='_blank';
+      dl.rel='noopener';
+      dl.textContent='Download firmware '+formatSelectedReleaseLabel(selected)+' ('+matchedFirmware.family+') (.bin)';
+      itemFw.appendChild(dl);
+    }else{
+      itemFw.textContent='No matching firmware variant published for HAL Sensor '+(info.halSensor||'unknown')+'.';
+    }
     list.appendChild(itemFw);
 
     var itemFs=document.createElement('li');
@@ -2147,7 +2208,8 @@ async function loadLatestReleaseInfo(){
       name:latestJson.name || '',
       publishedAt:latestJson.publishedAt || '',
       source:latestJson.source || '',
-      firmwareUrl:latestJson.firmwareUrl || AUTO_UPDATE_FIRMWARE_URL,
+      firmwareVariants:latestJson.firmwareVariants || null,
+      firmwareUrl:latestJson.firmwareUrl || '',
       spiffsUrl:latestJson.spiffsUrl || AUTO_UPDATE_SPIFFS_URL
     });
     if(!latestEntry) throw new Error('invalid latest payload');
@@ -3823,6 +3885,35 @@ function autoUpdateUnavailableReason(label,kind){
   return '';
 }
 
+function getAutoUpdateBlockedReason(label,selected,plan){
+  var needFirmware=!plan || !plan.canCompare || plan.needsFirmware;
+  var needSpiffs=!plan || !plan.canCompare || plan.needsSpiffs;
+  var blocked='';
+  if(needFirmware){
+    var halSensor=String(info.halSensor||'').trim();
+    var halFamily=getControllerHalSensorFamily();
+    var matchedFirmware=getMatchedFirmwareVariant(selected);
+    if(!halFamily){
+      return label+' could not determine this controller HAL Sensor. Reload the page and try again, or use Manual Update with a matched firmware + SPIFFS pair.';
+    }
+    if(!matchedFirmware){
+      return label+' is blocked because release '+formatSelectedReleaseLabel(selected)+' has no firmware variant for HAL Sensor '+(halSensor||halFamily)+'. Use Manual Update with the matching sensor-specific firmware file and the SPIFFS file from the same release.';
+    }
+  }
+  if(needFirmware){
+    blocked=autoUpdateUnavailableReason(label,'firmware');
+    if(blocked) return blocked;
+  }
+  if(needSpiffs){
+    blocked=autoUpdateUnavailableReason(label,'spiffs');
+    if(blocked) return blocked;
+  }
+  if(plan && plan.canCompare && !plan.needsFirmware && !plan.needsSpiffs){
+    return 'Selected release '+formatSelectedReleaseLabel(selected)+' is already installed on this controller.';
+  }
+  return '';
+}
+
 function loadBackupSessionState(){
   try{
     backupDownloadedThisSession=(sessionStorage.getItem(BACKUP_SESSION_KEY)==='1');
@@ -3879,16 +3970,12 @@ function updateFirmwareUiState(){
 
   var busyReason=otaBusy?'Another update is already running. Wait for completion.':'';
   var manualBaseReason=busyReason || otaUploadUnavailableReason('Manual update');
-  var autoReason=busyReason || autoUpdateUnavailableReason('Automatic update','firmware') || autoUpdateUnavailableReason('Automatic update','spiffs');
   var selected=getSelectedReleaseMeta();
   var plan=getSelectedReleaseInstallPlan(selected);
+  var autoReason=busyReason || getAutoUpdateBlockedReason('Automatic update',selected,plan);
   var selectedLabel=formatSelectedReleaseLabel(selected);
   var hasReleaseChoice=(availableReleases.length>1);
   var bothFilesSelected=!!(input.files && input.files[0] && fsInput.files && fsInput.files[0]);
-
-  if(!autoReason && plan.canCompare && !plan.needsFirmware && !plan.needsSpiffs){
-    autoReason='Selected release '+selectedLabel+' is already installed on this controller.';
-  }
 
   var disabled=(manualBaseReason!=='');
   var autoDisabled=(autoReason!=='');
@@ -4808,13 +4895,8 @@ async function runCombinedOtaUpdate(config){
 async function autoUpdateFirmware(){
   var selected=getSelectedReleaseMeta();
   var plan=getSelectedReleaseInstallPlan(selected);
-  var blocked=otaBusy?'Another update is already running. Wait for completion.':autoUpdateUnavailableReason('Automatic update','firmware');
-  if(!blocked){
-    blocked=autoUpdateUnavailableReason('Automatic update','spiffs');
-  }
-  if(!blocked && plan.canCompare && !plan.needsFirmware && !plan.needsSpiffs){
-    blocked='Selected release '+formatSelectedReleaseLabel(selected)+' is already installed on this controller.';
-  }
+  var blocked=otaBusy?'Another update is already running. Wait for completion.':getAutoUpdateBlockedReason('Automatic update',selected,plan);
+  var matchedFirmware=getMatchedFirmwareVariant(selected);
   if(blocked){
     ss('auto-ota-status','err',blocked);
     return;
@@ -4827,8 +4909,8 @@ async function autoUpdateFirmware(){
   if(!plan.canCompare || plan.needsFirmware){
     config.firmware={
       downloadUrl:getSelectedReleaseDownloadUrl('firmware'),
-      sha256Url:selected&&selected.firmwareSha256Url||null,
-      fileName:selected&&selected.firmwareAssetName||'ESPEED32.ino.bin',
+      sha256Url:matchedFirmware&&matchedFirmware.sha256Url||null,
+      fileName:matchedFirmware&&matchedFirmware.url?extractFileNameFromUrl(matchedFirmware.url,'ESPEED32.ino.bin'):'ESPEED32.ino.bin',
       progressPrefix:'auto-fw',
       downloadStatus:'Downloading selected firmware...'
     };
@@ -4837,7 +4919,7 @@ async function autoUpdateFirmware(){
     config.spiffs={
       downloadUrl:getSelectedReleaseDownloadUrl('spiffs'),
       sha256Url:selected&&selected.spiffsSha256Url||null,
-      fileName:selected&&selected.spiffsAssetName||'espeed32_spiffs.bin',
+      fileName:selected&&selected.spiffsUrl?extractFileNameFromUrl(selected.spiffsUrl,'espeed32_spiffs.bin'):'espeed32_spiffs.bin',
       progressPrefix:'auto-spiffs',
       downloadStatus:'Downloading selected filesystem image...'
     };

--- a/source/ESPEED32/data/ui/index.html
+++ b/source/ESPEED32/data/ui/index.html
@@ -3890,6 +3890,14 @@ function getAutoUpdateBlockedReason(label,selected,plan){
   var needSpiffs=!plan || !plan.canCompare || plan.needsSpiffs;
   var blocked='';
   if(needFirmware){
+    blocked=autoUpdateUnavailableReason(label,'firmware');
+    if(blocked) return blocked;
+  }
+  if(needSpiffs){
+    blocked=autoUpdateUnavailableReason(label,'spiffs');
+    if(blocked) return blocked;
+  }
+  if(needFirmware){
     var halSensor=String(info.halSensor||'').trim();
     var halFamily=getControllerHalSensorFamily();
     var matchedFirmware=getMatchedFirmwareVariant(selected);
@@ -3899,14 +3907,6 @@ function getAutoUpdateBlockedReason(label,selected,plan){
     if(!matchedFirmware){
       return label+' is blocked because release '+formatSelectedReleaseLabel(selected)+' has no firmware variant for HAL Sensor '+(halSensor||halFamily)+'. Use Manual Update with the matching sensor-specific firmware file and the SPIFFS file from the same release.';
     }
-  }
-  if(needFirmware){
-    blocked=autoUpdateUnavailableReason(label,'firmware');
-    if(blocked) return blocked;
-  }
-  if(needSpiffs){
-    blocked=autoUpdateUnavailableReason(label,'spiffs');
-    if(blocked) return blocked;
   }
   if(plan && plan.canCompare && !plan.needsFirmware && !plan.needsSpiffs){
     return 'Selected release '+formatSelectedReleaseLabel(selected)+' is already installed on this controller.';

--- a/source/ESPEED32/data/ui/index.html
+++ b/source/ESPEED32/data/ui/index.html
@@ -1821,6 +1821,16 @@ function normalizeFirmwareVariants(rawVariants,legacyFirmwareUrl,legacyFirmwareS
   return out;
 }
 
+function normalizeReleaseEntries(items){
+  var out=[];
+  if(!Array.isArray(items)) return out;
+  for(var i=0;i<items.length;i++){
+    var normalized=normalizeReleaseEntry(items[i]);
+    if(normalized) out.push(normalized);
+  }
+  return out;
+}
+
 function normalizeReleaseEntry(item){
   if(!item) return null;
 
@@ -1925,12 +1935,98 @@ function getMatchedFirmwareVariant(entry){
   return null;
 }
 
+function getReleaseDownloadInfo(entry,kind){
+  var selectedLabel=formatSelectedReleaseLabel(entry);
+  if(kind==='spiffs'){
+    if(!entry){
+      return {
+        ok:false,
+        code:releaseFetchTried?'release-unavailable':'release-loading',
+        message:releaseFetchTried?'release metadata is unavailable right now.':'release metadata is still loading.'
+      };
+    }
+    var spiffsUrl=String(entry.spiffsUrl||'').trim();
+    if(!spiffsUrl){
+      return {
+        ok:false,
+        code:'spiffs-missing',
+        message:'release '+selectedLabel+' does not publish a filesystem/UI image.'
+      };
+    }
+    return {
+      ok:true,
+      code:'ok',
+      kind:'spiffs',
+      url:spiffsUrl,
+      sha256Url:String(entry.spiffsSha256Url||'').trim()
+    };
+  }
+
+  if(!entry){
+    return {
+      ok:false,
+      code:releaseFetchTried?'release-unavailable':'release-loading',
+      message:releaseFetchTried?'release metadata is unavailable right now.':'release metadata is still loading.'
+    };
+  }
+
+  var halSensor=String(info.halSensor||'').trim();
+  var halFamily=getControllerHalSensorFamily();
+  var variants=(entry.firmwareVariants && typeof entry.firmwareVariants==='object')?entry.firmwareVariants:{};
+  var availableFamilies=[];
+  for(var key in variants){
+    if(!Object.prototype.hasOwnProperty.call(variants,key)) continue;
+    var familyKey=String(key||'').trim().toUpperCase();
+    if(!familyKey) continue;
+    var variant=variants[key]||{};
+    var variantUrl=String(variant.url||'').trim();
+    if(!variantUrl) continue;
+    availableFamilies.push(familyKey);
+  }
+
+  if(!halFamily){
+    return {
+      ok:false,
+      code:'hal-unknown',
+      message:'could not determine this controller HAL Sensor. Reload the page and try again, or use Manual Update with a matched firmware + SPIFFS pair.'
+    };
+  }
+
+  if(!availableFamilies.length){
+    return {
+      ok:false,
+      code:'variants-missing',
+      message:'release '+selectedLabel+' does not publish any firmware variants.'
+    };
+  }
+
+  var matched=getMatchedFirmwareVariant(entry);
+  if(!matched){
+    return {
+      ok:false,
+      code:'variant-missing',
+      message:'release '+selectedLabel+' has no firmware variant for HAL Sensor '+(halSensor||halFamily)+'. Published variants: '+availableFamilies.join(', ')+'. Use Manual Update with the matching sensor-specific firmware file and the SPIFFS file from the same release.',
+      halSensor:halSensor,
+      halFamily:halFamily,
+      availableFamilies:availableFamilies
+    };
+  }
+
+  return {
+    ok:true,
+    code:'ok',
+    kind:'firmware',
+    family:matched.family,
+    halSensor:halSensor,
+    halFamily:halFamily,
+    url:String(matched.url||'').trim(),
+    sha256Url:String(matched.sha256Url||'').trim()
+  };
+}
+
 function getSelectedReleaseDownloadUrl(kind){
-  var selected=getSelectedReleaseMeta();
-  if(!selected) return '';
-  if(kind==='spiffs') return String(selected.spiffsUrl||'').trim();
-  var variant=getMatchedFirmwareVariant(selected);
-  return variant?variant.url:'';
+  var info=getReleaseDownloadInfo(getSelectedReleaseMeta(),kind);
+  return info.ok?String(info.url||'').trim():'';
 }
 
 function normalizeInstalledReleaseVersion(value){
@@ -2114,26 +2210,31 @@ function updateReleaseInfoUi(){
     list.className='release-list';
 
     var itemFw=document.createElement('li');
-    var matchedFirmware=getMatchedFirmwareVariant(selected);
-    if(matchedFirmware && matchedFirmware.url){
+    var firmwareInfo=getReleaseDownloadInfo(selected,'firmware');
+    if(firmwareInfo.ok){
       var dl=document.createElement('a');
-      dl.href=matchedFirmware.url;
+      dl.href=firmwareInfo.url;
       dl.target='_blank';
       dl.rel='noopener';
-      dl.textContent='Download firmware '+formatSelectedReleaseLabel(selected)+' ('+matchedFirmware.family+') (.bin)';
+      dl.textContent='Download firmware '+formatSelectedReleaseLabel(selected)+' ('+firmwareInfo.family+') (.bin)';
       itemFw.appendChild(dl);
     }else{
-      itemFw.textContent='No matching firmware variant published for HAL Sensor '+(info.halSensor||'unknown')+'.';
+      itemFw.textContent=firmwareInfo.message.charAt(0).toUpperCase()+firmwareInfo.message.slice(1);
     }
     list.appendChild(itemFw);
 
     var itemFs=document.createElement('li');
-    var dlFs=document.createElement('a');
-    dlFs.href=selected.spiffsUrl || AUTO_UPDATE_SPIFFS_URL;
-    dlFs.target='_blank';
-    dlFs.rel='noopener';
-    dlFs.textContent='Download SPIFFS '+formatSelectedReleaseLabel(selected)+' (.bin)';
-    itemFs.appendChild(dlFs);
+    var spiffsInfo=getReleaseDownloadInfo(selected,'spiffs');
+    if(spiffsInfo.ok){
+      var dlFs=document.createElement('a');
+      dlFs.href=spiffsInfo.url;
+      dlFs.target='_blank';
+      dlFs.rel='noopener';
+      dlFs.textContent='Download SPIFFS '+formatSelectedReleaseLabel(selected)+' (.bin)';
+      itemFs.appendChild(dlFs);
+    }else{
+      itemFs.textContent=spiffsInfo.message.charAt(0).toUpperCase()+spiffsInfo.message.slice(1);
+    }
     list.appendChild(itemFs);
 
     el.appendChild(list);
@@ -2147,9 +2248,11 @@ function updateReleaseInfoUi(){
 async function loadLatestReleaseInfo(){
   var cached=readReleaseCache();
   if(cached){
-    if(Array.isArray(cached.releases) && cached.releases.length){
-      applyReleaseSelection(cached.releases, cached.latestTag || cached.latestReleaseVersion || '', cached.selectedReleaseVersion || '');
+    var cachedReleases=normalizeReleaseEntries(cached.releases);
+    if(cachedReleases.length){
+      applyReleaseSelection(cachedReleases, cached.latestTag || cached.latestReleaseVersion || '', cached.selectedReleaseVersion || '');
       releaseFetchTried=true;
+      writeReleaseCache();
       updateReleaseInfoUi();
     }else if(cached.tag || cached.url || cached.fwUrl || cached.spiffsUrl){
       var legacyEntry=normalizeReleaseEntry({
@@ -3879,37 +3982,27 @@ function autoUpdateUnavailableReason(label,kind){
   if(Number(info.portalMode||0)!==2){
     return label+' requires Client mode with internet access on this device.';
   }
-  if(!getSelectedReleaseDownloadUrl(kind||'firmware')){
-    return label+' release metadata is still loading.';
-  }
   return '';
 }
 
 function getAutoUpdateBlockedReason(label,selected,plan){
   var needFirmware=!plan || !plan.canCompare || plan.needsFirmware;
   var needSpiffs=!plan || !plan.canCompare || plan.needsSpiffs;
-  var blocked='';
-  if(needFirmware){
-    blocked=autoUpdateUnavailableReason(label,'firmware');
-    if(blocked) return blocked;
-  }
-  if(needSpiffs){
-    blocked=autoUpdateUnavailableReason(label,'spiffs');
-    if(blocked) return blocked;
-  }
-  if(needFirmware){
-    var halSensor=String(info.halSensor||'').trim();
-    var halFamily=getControllerHalSensorFamily();
-    var matchedFirmware=getMatchedFirmwareVariant(selected);
-    if(!halFamily){
-      return label+' could not determine this controller HAL Sensor. Reload the page and try again, or use Manual Update with a matched firmware + SPIFFS pair.';
-    }
-    if(!matchedFirmware){
-      return label+' is blocked because release '+formatSelectedReleaseLabel(selected)+' has no firmware variant for HAL Sensor '+(halSensor||halFamily)+'. Use Manual Update with the matching sensor-specific firmware file and the SPIFFS file from the same release.';
-    }
+  var blocked=autoUpdateUnavailableReason(label,'firmware');
+  if(blocked) return blocked;
+  if(!selected){
+    return label+' '+(releaseFetchTried?'release metadata is unavailable right now.':'release metadata is still loading.');
   }
   if(plan && plan.canCompare && !plan.needsFirmware && !plan.needsSpiffs){
     return 'Selected release '+formatSelectedReleaseLabel(selected)+' is already installed on this controller.';
+  }
+  if(needFirmware){
+    var firmwareInfo=getReleaseDownloadInfo(selected,'firmware');
+    if(!firmwareInfo.ok) return label+' '+firmwareInfo.message;
+  }
+  if(needSpiffs){
+    var spiffsInfo=getReleaseDownloadInfo(selected,'spiffs');
+    if(!spiffsInfo.ok) return label+' '+spiffsInfo.message;
   }
   return '';
 }
@@ -4896,7 +4989,8 @@ async function autoUpdateFirmware(){
   var selected=getSelectedReleaseMeta();
   var plan=getSelectedReleaseInstallPlan(selected);
   var blocked=otaBusy?'Another update is already running. Wait for completion.':getAutoUpdateBlockedReason('Automatic update',selected,plan);
-  var matchedFirmware=getMatchedFirmwareVariant(selected);
+  var firmwareInfo=getReleaseDownloadInfo(selected,'firmware');
+  var spiffsInfo=getReleaseDownloadInfo(selected,'spiffs');
   if(blocked){
     ss('auto-ota-status','err',blocked);
     return;
@@ -4908,18 +5002,18 @@ async function autoUpdateFirmware(){
   };
   if(!plan.canCompare || plan.needsFirmware){
     config.firmware={
-      downloadUrl:getSelectedReleaseDownloadUrl('firmware'),
-      sha256Url:matchedFirmware&&matchedFirmware.sha256Url||null,
-      fileName:matchedFirmware&&matchedFirmware.url?extractFileNameFromUrl(matchedFirmware.url,'ESPEED32.ino.bin'):'ESPEED32.ino.bin',
+      downloadUrl:firmwareInfo.ok?firmwareInfo.url:'',
+      sha256Url:firmwareInfo.ok?firmwareInfo.sha256Url:null,
+      fileName:firmwareInfo.ok?extractFileNameFromUrl(firmwareInfo.url,'ESPEED32.ino.bin'):'ESPEED32.ino.bin',
       progressPrefix:'auto-fw',
       downloadStatus:'Downloading selected firmware...'
     };
   }
   if(!plan.canCompare || plan.needsSpiffs){
     config.spiffs={
-      downloadUrl:getSelectedReleaseDownloadUrl('spiffs'),
-      sha256Url:selected&&selected.spiffsSha256Url||null,
-      fileName:selected&&selected.spiffsUrl?extractFileNameFromUrl(selected.spiffsUrl,'espeed32_spiffs.bin'):'espeed32_spiffs.bin',
+      downloadUrl:spiffsInfo.ok?spiffsInfo.url:'',
+      sha256Url:spiffsInfo.ok?spiffsInfo.sha256Url:null,
+      fileName:spiffsInfo.ok?extractFileNameFromUrl(spiffsInfo.url,'espeed32_spiffs.bin'):'espeed32_spiffs.bin',
       progressPrefix:'auto-spiffs',
       downloadStatus:'Downloading selected filesystem image...'
     };

--- a/source/ESPEED32/slot_ESC.h
+++ b/source/ESPEED32/slot_ESC.h
@@ -18,7 +18,7 @@
 /* Firmware Version */
 #define SW_MAJOR_VERSION 6
 #define SW_MINOR_VERSION 9
-#define SW_PATCH_VERSION 1
+#define SW_PATCH_VERSION 2
 
 /* Stored Variable Version */
 #define STORED_VAR_VERSION 24 /* Increment when stored value scale/format changes */


### PR DESCRIPTION
## Summary

Make automatic OTA firmware selection sensor-aware. The controller page now uses the connected controller's `HAL Sensor` to choose the matching firmware variant from the new `firmwareVariants` release metadata, instead of relying on a generic `firmwareUrl`.

## Changes

### Fixes
- Switch automatic update firmware selection from generic `firmwareUrl` to sensor-aware `firmwareVariants`
- Derive firmware family from `info.halSensor` in `This Controller`
- Match automatic firmware download to the connected controller sensor family:
  - `TLE493D`
  - `AS5600`
  - `AS5600L`
  - `MT6701`
  - `ANALOG`
- Block automatic firmware update when the selected release has no matching firmware variant for the connected controller
- Keep SPIFFS selection unchanged and shared across sensor variants
- Update release/download links in the UI to show the matched firmware variant instead of a generic firmware file
- Keep legacy cached metadata readable while preferring the new `firmwareVariants` shape when present

### Docs / UI
- Update automatic update wording to explain that firmware is matched to the controller HAL sensor
- Update warning text to explain that automatic update is blocked if no matching firmware variant exists

