### PR TITLE
ESPEED firmware v6.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,20 @@ Important hardware note:
 - `GPIO15` is an `ADC2` pin on ESP32, so it is better suited to non-drive-critical battery monitoring than to live throttle/brake tuning inputs
 - the standard `VBAT` profile assumes a `100k / 100k` battery divider on `GPIO15`; if your hardware differs, adjust `BOARD_BAT_RVIFBL` / `BOARD_BAT_RVIFBH` in your board profile so the `VBAT` reading is scaled correctly
 
+Falstad snippet for the standard `VBAT` divider on `GPIO15`:
+
+```text
+<cir f="1" ts="0.000005" ic="10.20027730826997" cb="50" pb="43" vr="5" mts="5e-11">
+  <v x="64 192 64 64" f="16" wf="0" maxv="4.2"/>
+  <r x="64 64 192 64" f="0" r="100000"/>
+  <r x="192 192 64 192" f="0" r="100000"/>
+  <w x="192 128 288 128" f="3"/>
+  <x x="299 128 393 131" f="0" si="12" te="GPIO15 (SPARE)"/>
+  <w x="192 128 192 192" f="0"/>
+  <w x="192 64 192 128" f="0"/>
+</cir>
+```
+
 Please verify the actual board routing against:
 
 - `ESPEED32_V3_0_schematic_PCB.pdf`

--- a/source/ESPEED32/connectivity_portal.cpp
+++ b/source/ESPEED32/connectivity_portal.cpp
@@ -74,7 +74,7 @@ static const size_t WIFI_BACKUP_TAG_LEN = 16;
 static const size_t WIFI_BACKUP_NONCE_B64_LEN = 16;
 static const size_t WIFI_BACKUP_TAG_B64_LEN = 24;
 static const size_t WIFI_BACKUP_PASS_B64_MAX_LEN = (((WIFI_STA_PASS_MAX_LEN + 2) / 3) * 4);
-static const size_t TELEMETRY_LIVE_RESPONSE_LIMIT = 32U;
+static const size_t TELEMETRY_LIVE_RESPONSE_LIMIT = 16U;
 static const size_t TELEMETRY_LIVE_EVENT_LIMIT = 4U;
 
 static bool readMacAddress(esp_mac_type_t type, uint8_t out[6]) {
@@ -3005,6 +3005,10 @@ static void handleTelemetryStatus() {
   g_wifiServer->send(200, "application/json", buildTelemetryStatusPayload(""));
 }
 
+static void handleTelemetryConfig() {
+  g_wifiServer->send(200, "application/json", buildTelemetryConfigSnapshotJson());
+}
+
 static void handleTelemetryStart() {
   if (!telemetryStartLogging(&g_storedVar,
                              g_antiSpinStepMs,
@@ -4188,6 +4192,7 @@ static void registerWebRoutes() {
   g_wifiServer->on("/api/apply", HTTP_POST, []() { if (!requireControllerAuth()) return; handleApply(); });
   g_wifiServer->on("/api/save", HTTP_POST, []() { if (!requireControllerAuth()) return; handleSave(); });
   g_wifiServer->on("/api/telemetry/status", HTTP_GET, []() { if (!requireControllerAuth()) return; handleTelemetryStatus(); });
+  g_wifiServer->on("/api/telemetry/config", HTTP_GET, []() { if (!requireControllerAuth()) return; handleTelemetryConfig(); });
   g_wifiServer->on("/api/telemetry/live", HTTP_GET, []() { if (!requireControllerAuth()) return; handleTelemetryLive(); });
   g_wifiServer->on("/api/telemetry/start", HTTP_POST, []() { if (!requireControllerAuth()) return; handleTelemetryStart(); });
   g_wifiServer->on("/api/telemetry/stop", HTTP_POST, []() { if (!requireControllerAuth()) return; handleTelemetryStop(); });

--- a/source/ESPEED32/connectivity_portal.cpp
+++ b/source/ESPEED32/connectivity_portal.cpp
@@ -43,6 +43,8 @@ static bool g_wifiConfigLoaded = false;
 static bool g_backupSecretLoaded = false;
 static bool g_backupSecretAvailable = false;
 static bool g_wifiRestartPending = false;
+static bool g_wifiStopPending = false;
+static bool g_wifiRestartAfterStopPending = false;
 static uint32_t g_wifiRestartAtMs = 0;
 static uint16_t g_wifiConfiguredMode = WIFI_CONFIG_AP;
 static uint8_t g_wifiActiveMode = WIFI_PORTAL_OFF;
@@ -72,7 +74,8 @@ static const size_t WIFI_BACKUP_TAG_LEN = 16;
 static const size_t WIFI_BACKUP_NONCE_B64_LEN = 16;
 static const size_t WIFI_BACKUP_TAG_B64_LEN = 24;
 static const size_t WIFI_BACKUP_PASS_B64_MAX_LEN = (((WIFI_STA_PASS_MAX_LEN + 2) / 3) * 4);
-static const size_t TELEMETRY_LIVE_RESPONSE_LIMIT = 120U;
+static const size_t TELEMETRY_LIVE_RESPONSE_LIMIT = 48U;
+static const size_t TELEMETRY_LIVE_EVENT_LIMIT = 8U;
 
 static bool readMacAddress(esp_mac_type_t type, uint8_t out[6]) {
   if (out == nullptr) return false;
@@ -83,6 +86,7 @@ static void serviceUsbSerialCommands();
 static void appendJsonEscaped(String& out, const char* in);
 static String buildTelemetryStatusPayload(const char* message);
 static String buildTelemetryLivePayload(uint32_t afterSeq, size_t limit);
+static void sendTelemetryLiveHttpPayload(uint32_t afterSeq, size_t limit);
 static String buildTelemetryConfigSnapshotJson();
 static String buildInfoJson();
 static void sendSerialLengthPrefixedPayload(const String& payload);
@@ -2909,16 +2913,17 @@ static String buildTelemetryStatusPayload(const char* message) {
 
 static String buildTelemetryLivePayload(uint32_t afterSeq, size_t limit) {
   static TelemetrySample samples[256];
-  static TelemetryEvent events[TELEMETRY_EVENT_BUFFER_CAPACITY];
+  static TelemetryEvent events[TELEMETRY_LIVE_EVENT_LIMIT];
   TelemetryStatus status;
+  bool includeEvents = (afterSeq == 0U);
   bool truncated = false;
   bool hasMore = false;
   bool eventsTruncated = false;
   size_t copied = telemetryCopySamplesAfter(afterSeq, samples, limit, &truncated, &hasMore, &status);
-  size_t eventCopied = telemetryCopyEvents(events, TELEMETRY_EVENT_BUFFER_CAPACITY, &eventsTruncated, nullptr);
+  size_t eventCopied = includeEvents ? telemetryCopyEvents(events, TELEMETRY_LIVE_EVENT_LIMIT, &eventsTruncated, nullptr) : 0U;
 
   String json;
-  json.reserve(1600 + (copied * 92U) + (eventCopied * 180U));
+  json.reserve(960 + (copied * 92U) + (eventCopied * 180U));
   json += "{\"ok\":true";
   appendTelemetryStatusFields(json, status);
   json += ",\"truncated\":";
@@ -2970,6 +2975,102 @@ static String buildTelemetryLivePayload(uint32_t afterSeq, size_t limit) {
 
   json += "]}";
   return json;
+}
+
+static void sendTelemetryLiveHttpPayload(uint32_t afterSeq, size_t limit) {
+  static TelemetrySample samples[256];
+  static TelemetryEvent events[TELEMETRY_LIVE_EVENT_LIMIT];
+  TelemetryStatus status;
+  bool includeEvents = (afterSeq == 0U);
+  bool truncated = false;
+  bool hasMore = false;
+  bool eventsTruncated = false;
+  size_t copied = telemetryCopySamplesAfter(afterSeq, samples, limit, &truncated, &hasMore, &status);
+  size_t eventCopied = includeEvents ? telemetryCopyEvents(events, TELEMETRY_LIVE_EVENT_LIMIT, &eventsTruncated, nullptr) : 0U;
+
+  g_wifiServer->setContentLength(CONTENT_LENGTH_UNKNOWN);
+  g_wifiServer->send(200, "application/json", "");
+
+  /* Chunk 1: header + status fields */
+  {
+    String hdr;
+    hdr.reserve(960);
+    hdr += "{\"ok\":true";
+    appendTelemetryStatusFields(hdr, status);
+    hdr += ",\"truncated\":";
+    hdr += truncated ? "true" : "false";
+    hdr += ",\"hasMore\":";
+    hdr += hasMore ? "true" : "false";
+    hdr += ",\"returned\":";
+    hdr += String((unsigned long)copied);
+    hdr += ",\"eventTruncated\":";
+    hdr += eventsTruncated ? "true" : "false";
+    hdr += ",\"events\":[";
+    g_wifiServer->sendContent(hdr);
+  }
+
+  /* Events are only included on reset / initial fetch. Repeating full car-param
+   * events on every incremental poll makes the live payload much heavier than needed. */
+  if (includeEvents && eventCopied > 0U) {
+    static const size_t EVENT_BATCH = 4U;
+    String evBatch;
+    for (size_t i = 0; i < eventCopied; i++) {
+      if (i % EVENT_BATCH == 0) {
+        evBatch = "";
+        evBatch.reserve(EVENT_BATCH * 192U);
+      }
+      if (i > 0) evBatch += ",";
+      appendTelemetryEventJson(evBatch, events[i]);
+      if (((i + 1) % EVENT_BATCH == 0) || ((i + 1) == eventCopied)) {
+        g_wifiServer->sendContent(evBatch);
+      }
+    }
+  }
+
+  g_wifiServer->sendContent("],\"samples\":[");
+
+  /* Samples batched 16 at a time (~1.2 KB per batch, avoids large heap allocs) */
+  {
+    static const size_t SAMPLE_BATCH = 16U;
+    String sBatch;
+    for (size_t i = 0; i < copied; i++) {
+      if (i % SAMPLE_BATCH == 0) {
+        sBatch = "";
+        sBatch.reserve(SAMPLE_BATCH * 80U);
+      }
+      const TelemetrySample& s = samples[i];
+      if (i > 0) sBatch += ",";
+      sBatch += "[";
+      sBatch += String((unsigned long)s.seq);
+      sBatch += ",";
+      sBatch += String((unsigned long)s.t_ms);
+      sBatch += ",";
+      sBatch += String((unsigned int)s.trigger_pct);
+      sBatch += ",";
+      sBatch += String((unsigned int)s.output_pct);
+      sBatch += ",";
+      sBatch += String((unsigned int)s.vin_mV);
+      sBatch += ",";
+      sBatch += String((unsigned int)s.current_mA);
+      sBatch += ",";
+      appendPercentX10JsonValue(sBatch, s.brake_pct);
+      sBatch += ",";
+      sBatch += String((unsigned int)s.sensi_halfPct);
+      sBatch += ",";
+      sBatch += String((unsigned int)s.carIndex);
+      sBatch += ",";
+      sBatch += String((unsigned int)s.releaseMode);
+      sBatch += ",";
+      sBatch += String((unsigned int)s.flags);
+      sBatch += "]";
+      if (((i + 1) % SAMPLE_BATCH == 0) || ((i + 1) == copied)) {
+        g_wifiServer->sendContent(sBatch);
+      }
+    }
+  }
+
+  g_wifiServer->sendContent("]}");
+  g_wifiServer->sendContent("");  /* Finalize chunked transfer so fetch() does not hang waiting for EOF. */
 }
 
 static String buildTelemetryConfigSnapshotJson() {
@@ -3033,7 +3134,7 @@ static void handleTelemetryClear() {
 static void handleTelemetryLive() {
   uint32_t afterSeq = getTelemetryArgU32("after", 0U);
   size_t limit = getTelemetryLiveLimit();
-  g_wifiServer->send(200, "application/json", buildTelemetryLivePayload(afterSeq, limit));
+  sendTelemetryLiveHttpPayload(afterSeq, limit);
 }
 
 static void handleTelemetryExportCsv() {
@@ -3456,7 +3557,7 @@ static void handleOtaUpload() {
     if (g_otaTargetSpiffs) {
       obdWriteString(&g_obd, 0, 8, 0, (char*)"SPIFFS Update", FONT_8x8, OBD_BLACK, 1);
     } else {
-      obdWriteString(&g_obd, 0, 16, 0, (char*)"OTA Update", FONT_8x8, OBD_BLACK, 1);
+      obdWriteString(&g_obd, 0, 16, 0, (char*)"FW Update", FONT_8x8, OBD_BLACK, 1);
     }
     obdWriteString(&g_obd, 0, 0, 3 * HEIGHT8x8, (char*)"Updating...", FONT_8x8, OBD_BLACK, 1);
     obdWriteString(&g_obd, 0, 0, 6 * HEIGHT8x8, (char*)"Do not power off!", FONT_6x8, OBD_BLACK, 1);
@@ -3566,7 +3667,7 @@ static void handleOta() {
   String requestToken = g_wifiServer->header("X-Ota-Token");
   if (!requestToken.isEmpty() && requestToken == g_otaRejectedToken) {
     g_otaRejectedToken = "";
-    g_wifiServer->send(409, "text/plain", "Another update is already running. Wait for completion.");
+    g_wifiServer->send(409, "text/plain", "Firmware update already in progress. Please wait for it to complete.");
     return;
   }
 
@@ -4259,16 +4360,52 @@ static void stopWiFiTransportOnly() {
   }
 
   WiFi.mode(WIFI_OFF);
+  delay(120);
   g_wifiActiveMode = WIFI_PORTAL_OFF;
   g_wifiApFallbackActive = false;
   g_wifiConnectedSsid[0] = '\0';
+}
+
+static void stopWiFiPortalNow() {
+  g_wifiStopPending = false;
+  bool willRestart = g_wifiRestartAfterStopPending && !isOtaInProgress();
+
+  if (g_wifiServer != nullptr) {
+    if (!willRestart) telemetryStopLogging();
+    g_wifiServer->stop();
+    delay(50);  /* Let lwIP drain in-flight requests before tearing down WiFi */
+    delete g_wifiServer;
+    g_wifiServer = nullptr;
+  } else if (!willRestart) {
+    telemetryStopLogging();  /* Server already null — still stop logging on clean shutdown */
+  }
+
+  stopWiFiTransportOnly();
+
+  if (g_spiffsMounted) {
+    SPIFFS.end();
+    g_spiffsMounted = false;
+  }
+
+  if (willRestart) {
+    g_wifiRestartAfterStopPending = false;
+    startWiFiPortal();
+  } else {
+    g_wifiRestartAfterStopPending = false;
+  }
 }
 
 static bool startWiFiApTransport() {
   char ssid[20];
   getWiFiPortalSsid(ssid, sizeof(ssid));
 
+  WiFi.persistent(false);
+  WiFi.disconnect(true, false, 250);
+  WiFi.mode(WIFI_OFF);
+  delay(120);
   WiFi.mode(WIFI_AP);
+  WiFi.setSleep(false);
+  esp_wifi_set_max_tx_power(84); /* Keep AP/client link as strong/stable as possible. */
   if (!WiFi.softAP(ssid, WIFI_PASS, WIFI_AP_CHANNEL, 0, WIFI_MAX_CONNECTIONS)) {
     WiFi.mode(WIFI_OFF);
     return false;
@@ -4364,8 +4501,15 @@ static bool startWiFiServerOnly() {
 }
 
 bool startWiFiPortal() {
+  g_wifiStopPending = false;
+  g_wifiRestartAfterStopPending = false;
+
   if (g_wifiServer != nullptr) {
     return true;
+  }
+
+  if (g_wifiActiveMode != WIFI_PORTAL_OFF) {
+    stopWiFiTransportOnly();  /* Recover from half-torn-down WiFi state before rebuilding portal/server. */
   }
 
   loadWiFiNetworkSettingsIfNeeded();
@@ -4402,8 +4546,17 @@ bool startWiFiPortal() {
 }
 
 void serviceWiFiPortal() {
+  if (g_wifiStopPending) {
+    stopWiFiPortalNow();
+    return;
+  }
+
   if (g_wifiServer != nullptr) {
     g_wifiServer->handleClient();
+  }
+
+  if (g_wifiStopPending) {
+    stopWiFiPortalNow();
   }
 }
 
@@ -4415,7 +4568,9 @@ void serviceConnectivityPortal() {
       (int32_t)(millis() - g_wifiRestartAtMs) >= 0) {
     g_wifiRestartPending = false;
     if (isWiFiPortalActive()) {
+      g_wifiRestartAfterStopPending = true;
       stopWiFiPortal();
+    } else {
       startWiFiPortal();
     }
   }
@@ -4429,20 +4584,12 @@ void stopWiFiPortal() {
   g_wifiRestartPending = false;
   g_wifiRestartAtMs = 0;
 
-  telemetryStopLogging();
-
-  if (g_wifiServer != nullptr) {
-    g_wifiServer->stop();
-    delete g_wifiServer;
-    g_wifiServer = nullptr;
+  if (g_wifiServer != nullptr || g_wifiStopPending) {
+    g_wifiStopPending = true;
+    return;
   }
 
-  stopWiFiTransportOnly();
-
-  if (g_spiffsMounted) {
-    SPIFFS.end();
-    g_spiffsMounted = false;
-  }
+  stopWiFiPortalNow();
 }
 
 

--- a/source/ESPEED32/connectivity_portal.cpp
+++ b/source/ESPEED32/connectivity_portal.cpp
@@ -2371,7 +2371,10 @@ static void handleSerialCommand(const String& cmd) {
                                g_encoderInvertEnabled,
                                g_adcVoltageRange_mV,
                                (uint8_t)g_carSel)) {
-      Serial.println("ERR:Telemetry start failed");
+      const char* err = telemetryGetLastStartError();
+      if (err == nullptr || err[0] == '\0') err = "Telemetry start failed";
+      Serial.print("ERR:");
+      Serial.println(err);
       return;
     }
     sendSerialLengthPrefixedPayload(buildTelemetryStatusPayload("Telemetry logging started"));
@@ -3003,7 +3006,12 @@ static void handleTelemetryStart() {
                              g_encoderInvertEnabled,
                              g_adcVoltageRange_mV,
                              (uint8_t)g_carSel)) {
-    g_wifiServer->send(500, "application/json", "{\"ok\":false,\"error\":\"Telemetry start failed\"}");
+    const char* err = telemetryGetLastStartError();
+    if (err == nullptr || err[0] == '\0') err = "Telemetry start failed";
+    String payload = "{\"ok\":false,\"error\":\"";
+    payload += err;
+    payload += "\"}";
+    g_wifiServer->send(500, "application/json", payload);
     return;
   }
 
@@ -3520,14 +3528,14 @@ static void handleOtaUpload() {
       if (g_otaTargetSpiffs) {
         obdWriteString(&g_obd, 0, 0, 24, (char*)"SPIFFS OK!", FONT_12x16, OBD_BLACK, 1);
       } else {
-        obdWriteString(&g_obd, 0, 8, 24, (char*)"OTA OK!", FONT_12x16, OBD_BLACK, 1);
+        obdWriteString(&g_obd, 0, 16, 24, (char*)"FW OK!", FONT_12x16, OBD_BLACK, 1);
       }
     } else {
       obdFill(&g_obd, OBD_WHITE, 1);
       if (g_otaTargetSpiffs) {
         obdWriteString(&g_obd, 0, 0, 24, (char*)"SPIFFS FAIL!", FONT_12x16, OBD_BLACK, 1);
       } else {
-        obdWriteString(&g_obd, 0, 0, 24, (char*)"OTA FAIL!", FONT_12x16, OBD_BLACK, 1);
+        obdWriteString(&g_obd, 0, 8, 24, (char*)"FW FAIL!", FONT_12x16, OBD_BLACK, 1);
       }
     }
     g_otaInProgress = false;

--- a/source/ESPEED32/connectivity_portal.cpp
+++ b/source/ESPEED32/connectivity_portal.cpp
@@ -87,6 +87,7 @@ static void serviceUsbSerialCommands();
 static void appendJsonEscaped(String& out, const char* in);
 static String buildTelemetryStatusPayload(const char* message);
 static String buildTelemetryLivePayload(uint32_t afterSeq, size_t limit);
+static String buildTelemetryEventsPayload();
 static String buildTelemetryConfigSnapshotJson();
 static String buildInfoJson();
 static void sendSerialLengthPrefixedPayload(const String& payload);
@@ -2284,6 +2285,7 @@ static void serviceUsbSerialCommands() {
  *   "SAVE"           → "OK - Saved to flash"
  *   "TSTATUS"        → "<bytecount>\n<json>"
  *   "TLIVE a l"      → "<bytecount>\n<json>" (afterSeq=a, limit=l)
+ *   "TEVENTS"        → "<bytecount>\n<json>"
  *   "TSTART"         → "<bytecount>\n<json>"
  *   "TSTOP"          → "<bytecount>\n<json>"
  *   "TCLEAR"         → "<bytecount>\n<json>"
@@ -2369,6 +2371,9 @@ static void handleSerialCommand(const String& cmd) {
     if (limit < 1U) limit = 1U;
     if (limit > TELEMETRY_USB_SERIAL_LIVE_LIMIT) limit = TELEMETRY_USB_SERIAL_LIVE_LIMIT;
     sendSerialLengthPrefixedPayload(buildTelemetryLivePayload(afterSeq, limit));
+
+  } else if (cmd == "TEVENTS") {
+    sendSerialLengthPrefixedPayload(buildTelemetryEventsPayload());
 
   } else if (cmd == "TSTART") {
     if (!telemetryStartLogging(&g_storedVar,
@@ -2977,6 +2982,33 @@ static String buildTelemetryLivePayload(uint32_t afterSeq, size_t limit) {
   return json;
 }
 
+static String buildTelemetryEventsPayload() {
+  static TelemetryEvent events[TELEMETRY_EVENT_BUFFER_CAPACITY];
+  TelemetryStatus status;
+  bool eventsTruncated = false;
+  size_t copied = telemetryCopyEvents(events, TELEMETRY_EVENT_BUFFER_CAPACITY, &eventsTruncated, &status);
+
+  String json;
+  json.reserve(768 + (copied * 180U));
+  json += "{\"ok\":true";
+  appendTelemetryStatusFields(json, status);
+  json += ",\"eventTruncated\":";
+  json += eventsTruncated ? "true" : "false";
+  json += ",\"eventsTruncated\":";
+  json += eventsTruncated ? "true" : "false";
+  json += ",\"returned\":";
+  json.concat((unsigned long)copied);
+  json += ",\"events\":[";
+  for (size_t i = 0; i < copied; i++) {
+    if (i > 0) {
+      json += ",";
+    }
+    appendTelemetryEventJson(json, events[i]);
+  }
+  json += "]}";
+  return json;
+}
+
 static String buildTelemetryConfigSnapshotJson() {
   TelemetryConfigSnapshot snapshot;
   TelemetryStatus status;
@@ -3043,6 +3075,10 @@ static void handleTelemetryLive() {
   uint32_t afterSeq = getTelemetryArgU32("after", 0U);
   size_t limit = getTelemetryLiveLimit();
   g_wifiServer->send(200, "application/json", buildTelemetryLivePayload(afterSeq, limit));
+}
+
+static void handleTelemetryEvents() {
+  g_wifiServer->send(200, "application/json", buildTelemetryEventsPayload());
 }
 
 static void handleTelemetryExportCsv() {
@@ -4195,6 +4231,7 @@ static void registerWebRoutes() {
   g_wifiServer->on("/api/telemetry/status", HTTP_GET, []() { if (!requireControllerAuth()) return; handleTelemetryStatus(); });
   g_wifiServer->on("/api/telemetry/config", HTTP_GET, []() { if (!requireControllerAuth()) return; handleTelemetryConfig(); });
   g_wifiServer->on("/api/telemetry/live", HTTP_GET, []() { if (!requireControllerAuth()) return; handleTelemetryLive(); });
+  g_wifiServer->on("/api/telemetry/events", HTTP_GET, []() { if (!requireControllerAuth()) return; handleTelemetryEvents(); });
   g_wifiServer->on("/api/telemetry/start", HTTP_POST, []() { if (!requireControllerAuth()) return; handleTelemetryStart(); });
   g_wifiServer->on("/api/telemetry/stop", HTTP_POST, []() { if (!requireControllerAuth()) return; handleTelemetryStop(); });
   g_wifiServer->on("/api/telemetry/clear", HTTP_POST, []() { if (!requireControllerAuth()) return; handleTelemetryClear(); });

--- a/source/ESPEED32/connectivity_portal.cpp
+++ b/source/ESPEED32/connectivity_portal.cpp
@@ -72,6 +72,7 @@ static const size_t WIFI_BACKUP_TAG_LEN = 16;
 static const size_t WIFI_BACKUP_NONCE_B64_LEN = 16;
 static const size_t WIFI_BACKUP_TAG_B64_LEN = 24;
 static const size_t WIFI_BACKUP_PASS_B64_MAX_LEN = (((WIFI_STA_PASS_MAX_LEN + 2) / 3) * 4);
+static const size_t TELEMETRY_LIVE_RESPONSE_LIMIT = 120U;
 
 static bool readMacAddress(esp_mac_type_t type, uint8_t out[6]) {
   if (out == nullptr) return false;
@@ -2337,7 +2338,7 @@ static void handleSerialCommand(const String& cmd) {
 
   } else if (cmd.startsWith("TLIVE")) {
     uint32_t afterSeq = 0U;
-    size_t limit = 256U;
+    size_t limit = TELEMETRY_LIVE_RESPONSE_LIMIT;
     int32_t firstSpace = cmd.indexOf(' ');
     if (firstSpace > 0 && firstSpace < (int32_t)cmd.length() - 1) {
       int32_t secondSpace = cmd.indexOf(' ', firstSpace + 1);
@@ -2362,7 +2363,7 @@ static void handleSerialCommand(const String& cmd) {
       }
     }
     if (limit < 1U) limit = 1U;
-    if (limit > 256U) limit = 256U;
+    if (limit > TELEMETRY_LIVE_RESPONSE_LIMIT) limit = TELEMETRY_LIVE_RESPONSE_LIMIT;
     sendSerialLengthPrefixedPayload(buildTelemetryLivePayload(afterSeq, limit));
 
   } else if (cmd == "TSTART") {
@@ -2699,12 +2700,12 @@ static uint32_t getTelemetryArgU32(const char* name, uint32_t defaultValue) {
 }
 
 static size_t getTelemetryLiveLimit() {
-  uint32_t limit = getTelemetryArgU32("limit", 120U);
+  uint32_t limit = getTelemetryArgU32("limit", TELEMETRY_LIVE_RESPONSE_LIMIT);
   if (limit == 0U) {
-    limit = 120U;
+    limit = TELEMETRY_LIVE_RESPONSE_LIMIT;
   }
-  if (limit > 256U) {
-    limit = 256U;
+  if (limit > TELEMETRY_LIVE_RESPONSE_LIMIT) {
+    limit = TELEMETRY_LIVE_RESPONSE_LIMIT;
   }
   return (size_t)limit;
 }
@@ -3009,7 +3010,7 @@ static void handleTelemetryStart() {
     const char* err = telemetryGetLastStartError();
     if (err == nullptr || err[0] == '\0') err = "Telemetry start failed";
     String payload = "{\"ok\":false,\"error\":\"";
-    payload += err;
+    appendJsonEscaped(payload, err);
     payload += "\"}";
     g_wifiServer->send(500, "application/json", payload);
     return;

--- a/source/ESPEED32/connectivity_portal.cpp
+++ b/source/ESPEED32/connectivity_portal.cpp
@@ -74,8 +74,8 @@ static const size_t WIFI_BACKUP_TAG_LEN = 16;
 static const size_t WIFI_BACKUP_NONCE_B64_LEN = 16;
 static const size_t WIFI_BACKUP_TAG_B64_LEN = 24;
 static const size_t WIFI_BACKUP_PASS_B64_MAX_LEN = (((WIFI_STA_PASS_MAX_LEN + 2) / 3) * 4);
-static const size_t TELEMETRY_LIVE_RESPONSE_LIMIT = 48U;
-static const size_t TELEMETRY_LIVE_EVENT_LIMIT = 8U;
+static const size_t TELEMETRY_LIVE_RESPONSE_LIMIT = 32U;
+static const size_t TELEMETRY_LIVE_EVENT_LIMIT = 4U;
 
 static bool readMacAddress(esp_mac_type_t type, uint8_t out[6]) {
   if (out == nullptr) return false;
@@ -86,7 +86,6 @@ static void serviceUsbSerialCommands();
 static void appendJsonEscaped(String& out, const char* in);
 static String buildTelemetryStatusPayload(const char* message);
 static String buildTelemetryLivePayload(uint32_t afterSeq, size_t limit);
-static void sendTelemetryLiveHttpPayload(uint32_t afterSeq, size_t limit);
 static String buildTelemetryConfigSnapshotJson();
 static String buildInfoJson();
 static void sendSerialLengthPrefixedPayload(const String& payload);
@@ -2786,19 +2785,19 @@ static String buildTelemetryConfigSummaryJsonFromSnapshot(const TelemetryConfigS
   json.reserve(960);
   json += "{";
   json += "\"selectedCarNumber\":";
-  json += String(activeCarIndex);
+  json.concat((unsigned int)activeCarIndex);
   json += ",\"antiSpinStepMs\":";
-  json += String(snapshot.antiSpinStepMs);
+  json.concat((unsigned int)snapshot.antiSpinStepMs);
   json += ",\"encoderInvert\":";
-  json += String(snapshot.encoderInvertEnabled ? 1U : 0U);
+  json.concat((unsigned int)(snapshot.encoderInvertEnabled ? 1U : 0U));
   json += ",\"adcVoltageRangeMv\":";
-  json += String(snapshot.adcVoltageRange_mV);
+  json.concat((unsigned int)snapshot.adcVoltageRange_mV);
   json += ",\"statusSlots\":[";
   for (uint8_t i = 0; i < STATUS_SLOTS; i++) {
     if (i > 0) {
       json += ",";
     }
-    json += String(normalizeStatusSlotForUi(snapshot.storedVar.statusSlot[i]));
+    json.concat((unsigned int)normalizeStatusSlotForUi(snapshot.storedVar.statusSlot[i]));
   }
   json += "],\"carNames\":";
   appendTelemetryCarNamesJson(json, snapshot.storedVar);
@@ -2811,19 +2810,19 @@ static String buildTelemetryConfigSummaryJsonFromSnapshot(const TelemetryConfigS
 static void appendTelemetryEventJson(String& json, const TelemetryEvent& event) {
   json += "{";
   json += "\"id\":";
-  json += String((unsigned long)event.id);
+  json.concat((unsigned long)event.id);
   json += ",\"tMs\":";
-  json += String((unsigned long)event.t_ms);
+  json.concat((unsigned long)event.t_ms);
   json += ",\"sampleSeq\":";
-  json += String((unsigned long)event.sampleSeq);
+  json.concat((unsigned long)event.sampleSeq);
   json += ",\"type\":\"";
   json += (event.type == TELEMETRY_EVENT_CAR_SELECT) ? "car_select" : "car_params";
   json += "\",\"carIndex\":";
-  json += String((unsigned int)event.carIndex);
+  json.concat((unsigned int)event.carIndex);
   json += ",\"previousCarIndex\":";
-  json += String((unsigned int)event.previousCarIndex);
+  json.concat((unsigned int)event.previousCarIndex);
   json += ",\"changedMask\":";
-  json += String((unsigned int)event.changedMask);
+  json.concat((unsigned int)event.changedMask);
   json += ",\"carParams\":";
   appendTelemetryCarParamJson(json, event.carParam);
   json += "}";
@@ -2889,7 +2888,7 @@ static void appendTelemetryStatusFields(String& json, const TelemetryStatus& sta
   json += ",\"statusSlots\":[";
   for (uint8_t i = 0; i < STATUS_SLOTS; i++) {
     if (i > 0) json += ",";
-    json += String(normalizeStatusSlotForUi(g_storedVar.statusSlot[i]));
+    json.concat((unsigned int)normalizeStatusSlotForUi(g_storedVar.statusSlot[i]));
   }
   json += "]}";
 }
@@ -2931,7 +2930,7 @@ static String buildTelemetryLivePayload(uint32_t afterSeq, size_t limit) {
   json += ",\"hasMore\":";
   json += hasMore ? "true" : "false";
   json += ",\"returned\":";
-  json += String((unsigned long)copied);
+  json.concat((unsigned long)copied);
   json += ",\"eventTruncated\":";
   json += eventsTruncated ? "true" : "false";
   json += ",\"events\":[";
@@ -2949,128 +2948,32 @@ static String buildTelemetryLivePayload(uint32_t afterSeq, size_t limit) {
       json += ",";
     }
     json += "[";
-    json += String((unsigned long)s.seq);
+    json.concat((unsigned long)s.seq);
     json += ",";
-    json += String((unsigned long)s.t_ms);
+    json.concat((unsigned long)s.t_ms);
     json += ",";
-    json += String((unsigned int)s.trigger_pct);
+    json.concat((unsigned int)s.trigger_pct);
     json += ",";
-    json += String((unsigned int)s.output_pct);
+    json.concat((unsigned int)s.output_pct);
     json += ",";
-    json += String((unsigned int)s.vin_mV);
+    json.concat((unsigned int)s.vin_mV);
     json += ",";
-    json += String((unsigned int)s.current_mA);
+    json.concat((unsigned int)s.current_mA);
     json += ",";
     appendPercentX10JsonValue(json, s.brake_pct);
     json += ",";
-    json += String((unsigned int)s.sensi_halfPct);
+    json.concat((unsigned int)s.sensi_halfPct);
     json += ",";
-    json += String((unsigned int)s.carIndex);
+    json.concat((unsigned int)s.carIndex);
     json += ",";
-    json += String((unsigned int)s.releaseMode);
+    json.concat((unsigned int)s.releaseMode);
     json += ",";
-    json += String((unsigned int)s.flags);
+    json.concat((unsigned int)s.flags);
     json += "]";
   }
 
   json += "]}";
   return json;
-}
-
-static void sendTelemetryLiveHttpPayload(uint32_t afterSeq, size_t limit) {
-  static TelemetrySample samples[256];
-  static TelemetryEvent events[TELEMETRY_LIVE_EVENT_LIMIT];
-  TelemetryStatus status;
-  bool includeEvents = (afterSeq == 0U);
-  bool truncated = false;
-  bool hasMore = false;
-  bool eventsTruncated = false;
-  size_t copied = telemetryCopySamplesAfter(afterSeq, samples, limit, &truncated, &hasMore, &status);
-  size_t eventCopied = includeEvents ? telemetryCopyEvents(events, TELEMETRY_LIVE_EVENT_LIMIT, &eventsTruncated, nullptr) : 0U;
-
-  g_wifiServer->setContentLength(CONTENT_LENGTH_UNKNOWN);
-  g_wifiServer->send(200, "application/json", "");
-
-  /* Chunk 1: header + status fields */
-  {
-    String hdr;
-    hdr.reserve(960);
-    hdr += "{\"ok\":true";
-    appendTelemetryStatusFields(hdr, status);
-    hdr += ",\"truncated\":";
-    hdr += truncated ? "true" : "false";
-    hdr += ",\"hasMore\":";
-    hdr += hasMore ? "true" : "false";
-    hdr += ",\"returned\":";
-    hdr += String((unsigned long)copied);
-    hdr += ",\"eventTruncated\":";
-    hdr += eventsTruncated ? "true" : "false";
-    hdr += ",\"events\":[";
-    g_wifiServer->sendContent(hdr);
-  }
-
-  /* Events are only included on reset / initial fetch. Repeating full car-param
-   * events on every incremental poll makes the live payload much heavier than needed. */
-  if (includeEvents && eventCopied > 0U) {
-    static const size_t EVENT_BATCH = 4U;
-    String evBatch;
-    for (size_t i = 0; i < eventCopied; i++) {
-      if (i % EVENT_BATCH == 0) {
-        evBatch = "";
-        evBatch.reserve(EVENT_BATCH * 192U);
-      }
-      if (i > 0) evBatch += ",";
-      appendTelemetryEventJson(evBatch, events[i]);
-      if (((i + 1) % EVENT_BATCH == 0) || ((i + 1) == eventCopied)) {
-        g_wifiServer->sendContent(evBatch);
-      }
-    }
-  }
-
-  g_wifiServer->sendContent("],\"samples\":[");
-
-  /* Samples batched 16 at a time (~1.2 KB per batch, avoids large heap allocs) */
-  {
-    static const size_t SAMPLE_BATCH = 16U;
-    String sBatch;
-    for (size_t i = 0; i < copied; i++) {
-      if (i % SAMPLE_BATCH == 0) {
-        sBatch = "";
-        sBatch.reserve(SAMPLE_BATCH * 80U);
-      }
-      const TelemetrySample& s = samples[i];
-      if (i > 0) sBatch += ",";
-      sBatch += "[";
-      sBatch += String((unsigned long)s.seq);
-      sBatch += ",";
-      sBatch += String((unsigned long)s.t_ms);
-      sBatch += ",";
-      sBatch += String((unsigned int)s.trigger_pct);
-      sBatch += ",";
-      sBatch += String((unsigned int)s.output_pct);
-      sBatch += ",";
-      sBatch += String((unsigned int)s.vin_mV);
-      sBatch += ",";
-      sBatch += String((unsigned int)s.current_mA);
-      sBatch += ",";
-      appendPercentX10JsonValue(sBatch, s.brake_pct);
-      sBatch += ",";
-      sBatch += String((unsigned int)s.sensi_halfPct);
-      sBatch += ",";
-      sBatch += String((unsigned int)s.carIndex);
-      sBatch += ",";
-      sBatch += String((unsigned int)s.releaseMode);
-      sBatch += ",";
-      sBatch += String((unsigned int)s.flags);
-      sBatch += "]";
-      if (((i + 1) % SAMPLE_BATCH == 0) || ((i + 1) == copied)) {
-        g_wifiServer->sendContent(sBatch);
-      }
-    }
-  }
-
-  g_wifiServer->sendContent("]}");
-  g_wifiServer->sendContent("");  /* Finalize chunked transfer so fetch() does not hang waiting for EOF. */
 }
 
 static String buildTelemetryConfigSnapshotJson() {
@@ -3134,7 +3037,7 @@ static void handleTelemetryClear() {
 static void handleTelemetryLive() {
   uint32_t afterSeq = getTelemetryArgU32("after", 0U);
   size_t limit = getTelemetryLiveLimit();
-  sendTelemetryLiveHttpPayload(afterSeq, limit);
+  g_wifiServer->send(200, "application/json", buildTelemetryLivePayload(afterSeq, limit));
 }
 
 static void handleTelemetryExportCsv() {

--- a/source/ESPEED32/connectivity_portal.cpp
+++ b/source/ESPEED32/connectivity_portal.cpp
@@ -74,6 +74,7 @@ static const size_t WIFI_BACKUP_TAG_LEN = 16;
 static const size_t WIFI_BACKUP_NONCE_B64_LEN = 16;
 static const size_t WIFI_BACKUP_TAG_B64_LEN = 24;
 static const size_t WIFI_BACKUP_PASS_B64_MAX_LEN = (((WIFI_STA_PASS_MAX_LEN + 2) / 3) * 4);
+static const size_t TELEMETRY_USB_SERIAL_LIVE_LIMIT = 96U;
 static const size_t TELEMETRY_LIVE_RESPONSE_LIMIT = 16U;
 static const size_t TELEMETRY_LIVE_EVENT_LIMIT = 4U;
 
@@ -2341,7 +2342,7 @@ static void handleSerialCommand(const String& cmd) {
 
   } else if (cmd.startsWith("TLIVE")) {
     uint32_t afterSeq = 0U;
-    size_t limit = TELEMETRY_LIVE_RESPONSE_LIMIT;
+    size_t limit = TELEMETRY_USB_SERIAL_LIVE_LIMIT;
     int32_t firstSpace = cmd.indexOf(' ');
     if (firstSpace > 0 && firstSpace < (int32_t)cmd.length() - 1) {
       int32_t secondSpace = cmd.indexOf(' ', firstSpace + 1);
@@ -2366,7 +2367,7 @@ static void handleSerialCommand(const String& cmd) {
       }
     }
     if (limit < 1U) limit = 1U;
-    if (limit > TELEMETRY_LIVE_RESPONSE_LIMIT) limit = TELEMETRY_LIVE_RESPONSE_LIMIT;
+    if (limit > TELEMETRY_USB_SERIAL_LIVE_LIMIT) limit = TELEMETRY_USB_SERIAL_LIVE_LIMIT;
     sendSerialLengthPrefixedPayload(buildTelemetryLivePayload(afterSeq, limit));
 
   } else if (cmd == "TSTART") {

--- a/source/ESPEED32/data/ui/chat-widget.js
+++ b/source/ESPEED32/data/ui/chat-widget.js
@@ -11,6 +11,7 @@
   var TURNSTILE_TOKEN_STALE_MS = 4 * 60 * 1000;
   var MAX_MESSAGE_LENGTH = 500;
   var MAX_STORED_MESSAGES = 24;
+  var MAX_REQUEST_HISTORY_MESSAGES = 12;
   var STORAGE_PREFIX = 'espeed32-chat-widget';
   var PLACEHOLDER_SITE_KEY = 'YOUR_TURNSTILE_SITE_KEY';
 
@@ -464,13 +465,21 @@
         return message &&
           (message.role === 'assistant' || message.role === 'user') &&
           typeof message.text === 'string';
-      }).slice(-MAX_STORED_MESSAGES);
+      }).slice(-MAX_STORED_MESSAGES).map(function (message) {
+        return {
+          role: message.role === 'user' ? 'user' : 'assistant',
+          text: String(message.text || ''),
+          sources: Array.isArray(message.sources) ? message.sources.slice(0, 6) : [],
+          responseId: typeof message.responseId === 'string' ? message.responseId.trim() : ''
+        };
+      });
     }
     if (!this.state.messages.length) {
       this.state.messages = [{
         role: 'assistant',
         text: this.text.welcomeMessage,
-        sources: []
+        sources: [],
+        responseId: ''
       }];
       this.persistMessages();
     }
@@ -662,7 +671,8 @@
     this.state.messages.push({
       role: message.role === 'user' ? 'user' : 'assistant',
       text: String(message.text || ''),
-      sources: Array.isArray(message.sources) ? message.sources.slice(0, 6) : []
+      sources: Array.isArray(message.sources) ? message.sources.slice(0, 6) : [],
+      responseId: typeof message.responseId === 'string' ? message.responseId.trim() : ''
     });
     if (this.state.messages.length > MAX_STORED_MESSAGES) {
       this.state.messages = this.state.messages.slice(-MAX_STORED_MESSAGES);
@@ -676,6 +686,42 @@
 
   Espeed32ChatWidget.prototype.persistMessages = function () {
     this.storage.set('messages', this.state.messages);
+  };
+
+  Espeed32ChatWidget.prototype.getRequestHistory = function () {
+    return this.state.messages
+      .filter(function (message) {
+        return message &&
+          (message.role === 'assistant' || message.role === 'user') &&
+          typeof message.text === 'string' &&
+          message.text.trim();
+      })
+      .slice(-MAX_REQUEST_HISTORY_MESSAGES)
+      .map(function (message) {
+        return {
+          role: message.role === 'user' ? 'user' : 'assistant',
+          content: String(message.text || '').trim()
+        };
+      });
+  };
+
+  Espeed32ChatWidget.prototype.getPreviousResponseId = function () {
+    var index;
+    var message;
+
+    for (index = this.state.messages.length - 1; index >= 0; index -= 1) {
+      message = this.state.messages[index];
+      if (
+        message &&
+        message.role === 'assistant' &&
+        typeof message.responseId === 'string' &&
+        message.responseId.trim()
+      ) {
+        return message.responseId.trim();
+      }
+    }
+
+    return '';
   };
 
   Espeed32ChatWidget.prototype.open = function (persist) {
@@ -943,6 +989,7 @@
     var payload;
     var answer;
     var sources;
+    var responseId;
 
     if (this.state.isSending) {
       return;
@@ -992,6 +1039,7 @@
       sources = Array.isArray(payload.sources) ? payload.sources.filter(function (source) {
         return source && typeof source.title === 'string' && typeof source.url === 'string';
       }).slice(0, 6) : [];
+      responseId = typeof payload.responseId === 'string' && payload.responseId.trim() ? payload.responseId.trim() : '';
       if (typeof payload.answer !== 'string') {
         throw {
           kind: 'invalid_response',
@@ -1001,7 +1049,8 @@
       this.addMessage({
         role: 'assistant',
         text: answer,
-        sources: sources
+        sources: sources,
+        responseId: responseId
       }, true);
     } catch (error) {
       this.showStatus(
@@ -1025,16 +1074,24 @@
     }
 
     var response;
+    var requestPayload = {
+      message: message,
+      turnstileToken: turnstileToken,
+      history: this.getRequestHistory()
+    };
+    var previousResponseId = this.getPreviousResponseId();
+
+    if (previousResponseId) {
+      requestPayload.previousResponseId = previousResponseId;
+    }
+
     try {
       response = await fetch(this.config.apiUrl, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json'
         },
-        body: JSON.stringify({
-          message: message,
-          turnstileToken: turnstileToken
-        })
+        body: JSON.stringify(requestPayload)
       });
     } catch (error) {
       throw {
@@ -1082,7 +1139,8 @@
       sources: [
         { title: 'ESPEED32 Docs', url: docsUrl },
         { title: 'ESPEED32 UI', url: uiUrl }
-      ]
+      ],
+      responseId: ''
     };
   };
 

--- a/source/ESPEED32/data/ui/index.html
+++ b/source/ESPEED32/data/ui/index.html
@@ -1376,7 +1376,7 @@ var telemetryPersistentError='';
 var telemetryPanelPinned=false;
 var telemetryRedrawQueued=false;
 var telemetryConfigSnapshot=null;
-var telemetryFetchAbortController=null;
+var telemetryFetchAbortControllers=new Set();
 var telemetryPollingPausedByError=false;
 var telemetryLastSuccessAtMs=0;
 var telemetryLastErrorAtMs=0;
@@ -2532,7 +2532,7 @@ async function telemetryFetchWithTimeout(url,options,timeoutMs){
     return await fetch(url,options||{});
   }
   var controller=new AbortController();
-  telemetryFetchAbortController=controller;
+  telemetryFetchAbortControllers.add(controller);
   var requestOptions=Object.assign({},options||{});
   requestOptions.signal=controller.signal;
   var timedOut=false;
@@ -2548,18 +2548,18 @@ async function telemetryFetchWithTimeout(url,options,timeoutMs){
     }
     throw err;
   }finally{
-    if(telemetryFetchAbortController===controller){
-      telemetryFetchAbortController=null;
-    }
+    telemetryFetchAbortControllers.delete(controller);
     clearTimeout(timer);
   }
 }
 
 function cancelTelemetryFetches(){
-  if(!telemetryFetchAbortController) return;
-  try{
-    telemetryFetchAbortController.abort();
-  }catch(_){}
+  if(!telemetryFetchAbortControllers.size) return;
+  var snapshot=Array.from(telemetryFetchAbortControllers);
+  telemetryFetchAbortControllers.clear();
+  snapshot.forEach(function(c){
+    try{ c.abort(); }catch(_){}
+  });
 }
 
 async function telemetryFetchStatusTransport(){

--- a/source/ESPEED32/data/ui/index.html
+++ b/source/ESPEED32/data/ui/index.html
@@ -647,8 +647,8 @@ form{margin:0}
 .update-panel .tiny,
 .update-panel .warn,
 .progress-head span{
-  overflow-wrap:anywhere;
-  word-break:break-word;
+  overflow-wrap:break-word;
+  word-break:normal;
 }
 .progress-head span:first-child{
   flex:1 1 180px;
@@ -1380,6 +1380,7 @@ var telemetryFetchAbortController=null;
 var telemetryPollingPausedByError=false;
 var telemetryLastSuccessAtMs=0;
 var telemetryLastErrorAtMs=0;
+var TELEMETRY_USB_LIVE_LIMIT=96;
 var TELEMETRY_WIFI_LIVE_LIMIT=16;
 var TELEMETRY_WIFI_TAIL_SAMPLES=64;
 var TELEMETRY_WIFI_MAX_FETCH_LOOPS=4;
@@ -2508,6 +2509,24 @@ function telemetryUnavailableText(){
   return 'Telemetry is available on the controller WiFi page or over USB WebSerial.';
 }
 
+async function telemetryHydrateStatusFromDevice(){
+  if(!telemetryAvailable()) return false;
+  try{
+    var status=await telemetryFetchStatusTransport();
+    telemetryStatus=status;
+    if(status && (status.loggingActive || status.hasData)){
+      telemetryPanelPinned=true;
+    }
+    telemetryPersistentError='';
+    updateTelemetryUiState();
+    updateTelemetryMetrics();
+    drawTelemetryPlot();
+    return true;
+  }catch(_){
+    return false;
+  }
+}
+
 async function telemetryFetchWithTimeout(url,options,timeoutMs){
   if(typeof AbortController==='undefined'){
     return await fetch(url,options||{});
@@ -2556,7 +2575,7 @@ async function telemetryFetchStatusTransport(){
 
 async function telemetryFetchLiveTransport(after,limit){
   if(telemetryUsesUsb()){
-    var usbLimit=Math.min(Number(limit||256),96);
+    var usbLimit=Math.min(Number(limit||256),TELEMETRY_USB_LIVE_LIMIT);
     return await usbReadJsonResponse('TLIVE '+String(after||0)+' '+String(usbLimit),15000,120000);
   }
   var wifiLimit=Math.min(Number(limit||256),TELEMETRY_WIFI_LIVE_LIMIT);
@@ -2640,7 +2659,7 @@ async function telemetryCollectExportData(){
   var samples=[];
   var events=[];
   var restarts=0;
-  var batchLimit=telemetryUsesUsb()?96:TELEMETRY_WIFI_LIVE_LIMIT;
+  var batchLimit=telemetryUsesUsb()?TELEMETRY_USB_LIVE_LIMIT:TELEMETRY_WIFI_LIVE_LIMIT;
   var targetSamples=Math.max(
     1,
     Number((telemetryStatus&&telemetryStatus.storedCount)||0),
@@ -4300,6 +4319,8 @@ async function loadInfo(){
   if(apiOk){
     if(hadPolling){
       startTelemetryPollingIfAvailable(false);
+    }else if(!otaBusy){
+      await telemetryHydrateStatusFromDevice();
     }
   }else{
     stopTelemetryPolling();
@@ -4818,6 +4839,10 @@ async function pauseBackgroundActivityForOta(statusId){
 
   if(telemetryFetchBusy){
     throw new Error('Telemetry requests did not settle. Wait a moment and try the update again.');
+  }
+
+  if(!telemetryUsesUsb() && telemetryAvailable()){
+    await telemetryHydrateStatusFromDevice();
   }
 
   if(!telemetryUsesUsb() && telemetryStatus && telemetryStatus.loggingActive){

--- a/source/ESPEED32/data/ui/index.html
+++ b/source/ESPEED32/data/ui/index.html
@@ -1252,12 +1252,8 @@ form{margin:0}
 <option value="">Loading latest...</option>
 </select>
 </div>
-<p id="fw-release-note" class="tiny">Choose which official release automatic update should install. Firmware variant is matched to this controller's HAL Sensor when release metadata provides one.</p>
-<p id="fw-release-source" class="tiny" style="display:none"></p>
+<p class="tiny"><span id="fw-release-note">Release pair to install.</span> <span id="fw-release-source" style="display:none"></span></p>
 <button type="button" class="btn dl" id="btn-fw-auto" onclick="autoUpdateFirmware()">Install Selected Release</button>
-<p id="fw-auto-desc" class="tiny">Downloads the selected release pair, uploads firmware first and filesystem second, then reboots once at the end.</p>
-<p class="tiny">Recommended when you want a matched official release without downloading files manually.</p>
-<p class="tiny warn">Automatic update now tries to match firmware to this controller's HAL Sensor. If no matching firmware variant exists for the selected release, automatic firmware update is blocked and you must use Manual Update with the matching sensor-specific firmware file and the SPIFFS file from the same release.</p>
 </div>
 <p id="ota-note" style="display:none" class="warn"></p>
 <div id="auto-fw-progress" class="progress-wrap" aria-live="polite">
@@ -1356,8 +1352,14 @@ var telemetryUiBusy=false;
 var telemetryPollTimer=null;
 var telemetryPollIntervalMs=250;
 var telemetryPersistentError='';
+var telemetryPanelPinned=false;
 var telemetryRedrawQueued=false;
 var telemetryConfigSnapshot=null;
+var telemetryFetchAbortController=null;
+var TELEMETRY_WIFI_LIVE_LIMIT=48;
+var TELEMETRY_WIFI_TAIL_SAMPLES=128;
+var TELEMETRY_WIFI_MAX_FETCH_LOOPS=4;
+var TELEMETRY_USB_MAX_FETCH_LOOPS=20;
 var LAP_OVERLAY_SOURCE_NONE='none';
 var LAP_OVERLAY_SOURCE_CURRENT='current';
 var LAP_OVERLAY_SOURCE_IMPORT='import';
@@ -2057,18 +2059,18 @@ function getSelectedReleaseInstallPlan(entry){
 function describeAutoUpdatePlan(entry,plan){
   var selectedLabel=formatSelectedReleaseLabel(entry);
   if(plan.canCompare && !plan.needsFirmware && !plan.needsSpiffs){
-    return 'Selected release '+selectedLabel+' is already installed on this controller.';
+    return selectedLabel+' is already installed.';
   }
   if(plan.canCompare && !plan.needsFirmware && plan.needsSpiffs){
-    return 'Firmware already matches '+selectedLabel+'. Automatic update will download and install only the filesystem/UI image, then reboot once at the end.';
+    return 'Installs filesystem/UI only for '+selectedLabel+'.';
   }
   if(plan.canCompare && plan.needsFirmware && !plan.needsSpiffs){
-    return 'Filesystem/UI already matches '+selectedLabel+'. Automatic update will download and install only the firmware image, then reboot once at the end.';
+    return 'Installs firmware only for '+selectedLabel+'.';
   }
   if(entry && !entry.isLatest){
-    return 'Downloads release '+selectedLabel+', uploads firmware first and filesystem second, then reboots once at the end.';
+    return 'Installs '+selectedLabel+'. Firmware first, filesystem second, one reboot.';
   }
-  return 'Downloads the selected official release pair, uploads firmware first and filesystem second, then reboots once at the end.';
+  return 'Installs selected release pair. One reboot.';
 }
 
 function updateReleaseVersionUi(){
@@ -2085,8 +2087,8 @@ function updateReleaseVersionUi(){
     select.appendChild(loadingOpt);
     select.disabled=true;
     note.textContent=releaseFetchTried
-      ?'Version list unavailable right now. Automatic update will use the latest available release pair.'
-      :'Checks available releases and defaults to the latest version.';
+      ?'Using latest available release.'
+      :'Loading release list...';
     source.style.display='none';
     source.textContent='';
     return;
@@ -2107,12 +2109,12 @@ function updateReleaseVersionUi(){
   var plan=getSelectedReleaseInstallPlan(selected);
   var singleLatestFallback=(availableReleases.length<2 && selected && selected.version==='latest');
   note.textContent=singleLatestFallback
-    ?'Version list unavailable right now. Automatic update will use the latest available release pair.'
-    :'This selector controls which firmware + filesystem pair automatic update installs.';
+    ?'Using latest available release.'
+    :'Release pair to install.';
 
   if(selected && selected.source){
-    source.style.display='block';
-    source.appendChild(document.createTextNode('Source release: '));
+    source.style.display='inline';
+    source.appendChild(document.createTextNode('Source: '));
     var link=document.createElement('a');
     link.href=selected.source;
     link.target='_blank';
@@ -2482,11 +2484,46 @@ function telemetryUnavailableText(){
   return 'Telemetry is available on the controller WiFi page or over USB WebSerial.';
 }
 
+async function telemetryFetchWithTimeout(url,options,timeoutMs){
+  if(typeof AbortController==='undefined'){
+    return await fetch(url,options||{});
+  }
+  var controller=new AbortController();
+  telemetryFetchAbortController=controller;
+  var requestOptions=Object.assign({},options||{});
+  requestOptions.signal=controller.signal;
+  var timedOut=false;
+  var timer=setTimeout(function(){
+    timedOut=true;
+    controller.abort();
+  },Math.max(1000,Number(timeoutMs||10000)));
+  try{
+    return await fetch(url,requestOptions);
+  }catch(err){
+    if(err && err.name==='AbortError'){
+      throw new Error(timedOut?'Telemetry request timed out':'Telemetry request cancelled');
+    }
+    throw err;
+  }finally{
+    if(telemetryFetchAbortController===controller){
+      telemetryFetchAbortController=null;
+    }
+    clearTimeout(timer);
+  }
+}
+
+function cancelTelemetryFetches(){
+  if(!telemetryFetchAbortController) return;
+  try{
+    telemetryFetchAbortController.abort();
+  }catch(_){}
+}
+
 async function telemetryFetchStatusTransport(){
   if(telemetryUsesUsb()){
     return await usbReadJsonResponse('TSTATUS',10000,40000);
   }
-  var resp=await fetch('/api/telemetry/status',{cache:'no-store'});
+  var resp=await telemetryFetchWithTimeout('/api/telemetry/status',{cache:'no-store'},8000);
   if(!resp.ok) throw new Error('Telemetry unavailable (HTTP '+resp.status+')');
   var data=await resp.json();
   if(!data || !data.ok) throw new Error((data&&data.error)?data.error:'Telemetry fetch failed');
@@ -2498,8 +2535,8 @@ async function telemetryFetchLiveTransport(after,limit){
     var usbLimit=Math.min(Number(limit||256),96);
     return await usbReadJsonResponse('TLIVE '+String(after||0)+' '+String(usbLimit),15000,120000);
   }
-  var wifiLimit=Math.min(Number(limit||256),120);
-  var resp=await fetch('/api/telemetry/live?after='+encodeURIComponent(after||0)+'&limit='+encodeURIComponent(wifiLimit),{cache:'no-store'});
+  var wifiLimit=Math.min(Number(limit||256),TELEMETRY_WIFI_LIVE_LIMIT);
+  var resp=await telemetryFetchWithTimeout('/api/telemetry/live?after='+encodeURIComponent(after||0)+'&limit='+encodeURIComponent(wifiLimit),{cache:'no-store'},10000);
   if(!resp.ok) throw new Error('Telemetry unavailable (HTTP '+resp.status+')');
   var data=await resp.json();
   if(!data || !data.ok) throw new Error((data&&data.error)?data.error:'Telemetry fetch failed');
@@ -2511,7 +2548,7 @@ async function telemetryPostTransport(action){
     return await usbReadJsonResponse(action,15000,40000);
   }
   var url='/api/telemetry/'+action.toLowerCase().slice(1);
-  var resp=await fetch(url,{method:'POST'});
+  var resp=await telemetryFetchWithTimeout(url,{method:'POST'},10000);
   var data=await resp.json();
   if(!resp.ok || !data.ok) throw new Error((data&&data.error)?data.error:('HTTP '+resp.status));
   return data;
@@ -2747,6 +2784,15 @@ function normalizeTelemetryError(err){
   if(message==='The string did not match the expected pattern.'){
     return 'Telemetry is unavailable on this page.';
   }
+  if(message==='Load failed'){
+    return 'Telemetry live update dropped. The controller WiFi page is still connected, but the live telemetry response was too heavy or interrupted.';
+  }
+  if(message==='Telemetry request timed out'){
+    return 'Telemetry live update timed out. The controller stayed online, but the live response did not finish in time.';
+  }
+  if(message==='Telemetry request cancelled'){
+    return 'Telemetry was paused so the firmware update could start cleanly.';
+  }
   if(message.indexOf('Failed to fetch')!==-1){
     return 'Telemetry is unavailable on this page.';
   }
@@ -2794,7 +2840,8 @@ function startTelemetryPollingIfAvailable(refreshNow){
   if(otaBusy && !telemetryUsesUsb()) return;
   if(!telemetryAvailable()) return;
   if(refreshNow) syncTelemetryHistory(true,true);
-  telemetryPollTimer=setInterval(function(){ syncTelemetryHistory(false,true); },telemetryPollIntervalMs);
+  var intervalMs=telemetryUsesUsb()?telemetryPollIntervalMs:Math.max(1000,telemetryPollIntervalMs);
+  telemetryPollTimer=setInterval(function(){ syncTelemetryHistory(false,true); },intervalMs);
 }
 
 function setAnchorDisabled(id,disabled,href){
@@ -2919,7 +2966,7 @@ function updateTelemetryAvailabilityNote(){
 
 function telemetryShouldShowDetails(){
   var status=telemetryStatus||{};
-  return !!(status.loggingActive || status.hasData || telemetrySamples.length);
+  return !!(telemetryPanelPinned || telemetryUiBusy || status.loggingActive || status.hasData || telemetrySamples.length);
 }
 
 function updateTelemetryLayout(){
@@ -3796,6 +3843,7 @@ async function syncTelemetryHistory(reset,silent,persistError){
     telemetryAfterSeq=0;
     telemetrySessionId=0;
     telemetryPersistentError='';
+    telemetryPanelPinned=false;
     lapOverlayRefreshFromCurrentTelemetry(true);
     updateTelemetryUiState();
     updateTelemetryMetrics();
@@ -3814,10 +3862,24 @@ async function syncTelemetryHistory(reset,silent,persistError){
       telemetryEvents=[];
       telemetryAfterSeq=0;
       telemetrySessionId=0;
+      if(!telemetryUsesUsb()){
+        var statusSeed=await telemetryFetchStatusTransport();
+        telemetryStatus=statusSeed;
+        telemetrySessionId=Number(statusSeed.sessionId||0);
+        var latestSeq=Number(statusSeed.latestSeq||0);
+        var oldestSeq=Number(statusSeed.oldestSeq||0);
+        var tailCount=Math.max(32,Math.min(TELEMETRY_WIFI_TAIL_SAMPLES,Number(statusSeed.capacity||TELEMETRY_WIFI_TAIL_SAMPLES)));
+        if(latestSeq>0){
+          var firstWanted=Math.max(1,latestSeq-tailCount+1);
+          if(oldestSeq>0 && firstWanted<oldestSeq) firstWanted=oldestSeq;
+          telemetryAfterSeq=firstWanted>1?(firstWanted-1):0;
+        }
+      }
     }
 
     var safety=0;
-    while(safety<20){
+    var maxLoops=telemetryUsesUsb()?TELEMETRY_USB_MAX_FETCH_LOOPS:TELEMETRY_WIFI_MAX_FETCH_LOOPS;
+    while(safety<maxLoops){
       var after=telemetryAfterSeq;
       var data=await telemetryFetchLiveTransport(after,256);
 
@@ -3834,7 +3896,9 @@ async function syncTelemetryHistory(reset,silent,persistError){
       }
 
       telemetryStatus=data;
-      telemetryEvents=Array.isArray(data.events)?data.events:[];
+      if(Array.isArray(data.events) && (after===0 || data.events.length>0)){
+        telemetryEvents=data.events;
+      }
       telemetrySessionId=Number(data.sessionId||0);
       if(Array.isArray(data.samples)){
         data.samples.forEach(function(sample){
@@ -3879,10 +3943,9 @@ async function telemetryPostAction(url,successText,resetHistory){
     ss('tst','err',telemetryUnavailableText());
     return;
   }
-  var hadUsbPolling=telemetryUsesUsb();
-  if(hadUsbPolling){
-    stopTelemetryPolling();
-  }
+  telemetryPanelPinned=true;
+  var hadPolling=!!telemetryPollTimer;
+  stopTelemetryPolling();
   telemetryUiBusy=true;
   updateTelemetryUiState();
   try{
@@ -3899,20 +3962,20 @@ async function telemetryPostAction(url,successText,resetHistory){
     updateTelemetryUiState();
     updateTelemetryMetrics();
     drawTelemetryPlot();
-    await syncTelemetryHistory(!!resetHistory,true);
     ss('tst','ok',successText||data.message||'Done');
   }catch(e){
     ss('tst','err',normalizeTelemetryError(e));
   }finally{
     telemetryUiBusy=false;
     updateTelemetryUiState();
-    if(hadUsbPolling){
-      startTelemetryPollingIfAvailable(false);
+    if(hadPolling || telemetryAvailable()){
+      startTelemetryPollingIfAvailable(true);
     }
   }
 }
 
 async function telemetryRefresh(){
+  telemetryPanelPinned=true;
   await syncTelemetryHistory(true,false,false);
 }
 
@@ -4062,14 +4125,13 @@ function updateFirmwareUiState(){
   var btn=document.getElementById('btn-ota-upload');
   var releaseSelect=document.getElementById('fw-release-select');
   var autoBtn=document.getElementById('btn-fw-auto');
-  var autoDesc=document.getElementById('fw-auto-desc');
   var note=document.getElementById('ota-note');
   var fsInput=document.getElementById('spiffs');
   var manualDesc=document.getElementById('spiffs-auto-desc');
   var fsNote=document.getElementById('spiffs-note');
-  if(!input || !btn || !releaseSelect || !autoBtn || !autoDesc || !note || !fsInput || !manualDesc || !fsNote) return;
+  if(!input || !btn || !releaseSelect || !autoBtn || !note || !fsInput || !manualDesc || !fsNote) return;
 
-  var busyReason=otaBusy?'Another update is already running. Wait for completion.':'';
+  var busyReason=otaBusy?'Firmware update in progress — please wait.':'';
   var manualBaseReason=busyReason || otaUploadUnavailableReason('Manual update');
   var selected=getSelectedReleaseMeta();
   var plan=getSelectedReleaseInstallPlan(selected);
@@ -4094,7 +4156,6 @@ function updateFirmwareUiState(){
   note.textContent=autoReason;
   autoBtn.disabled=autoDisabled;
   autoBtn.classList.toggle('disabled',autoDisabled);
-  autoDesc.textContent=autoReason || describeAutoUpdatePlan(selected,plan);
 
   fsNote.style.display=manualBaseReason!==''?'block':'none';
   fsNote.textContent=manualBaseReason;
@@ -4692,12 +4753,27 @@ function setOtaBusy(busy){
 async function pauseBackgroundActivityForOta(statusId){
   otaPausedTelemetryPolling=!!telemetryPollTimer;
   stopTelemetryPolling();
-  if(!telemetryFetchBusy) return;
+  cancelTelemetryFetches();
 
-  ss(statusId,'','Waiting for background requests to settle...');
+  ss(statusId,'','Pausing telemetry...');
   var deadline=Date.now()+3000;
   while(telemetryFetchBusy && Date.now()<deadline){
     await sleepMs(50);
+  }
+
+  if(telemetryFetchBusy){
+    throw new Error('Telemetry requests did not settle. Wait a moment and try the update again.');
+  }
+
+  if(!telemetryUsesUsb() && telemetryStatus && telemetryStatus.loggingActive){
+    ss(statusId,'','Stopping telemetry logging...');
+    var stopData=await telemetryPostTransport('TSTOP');
+    telemetryStatus=stopData||telemetryStatus;
+    telemetryPersistentError='';
+    updateTelemetryUiState();
+    updateTelemetryMetrics();
+    drawTelemetryPlot();
+    await sleepMs(150);
   }
 }
 
@@ -4997,7 +5073,7 @@ async function runCombinedOtaUpdate(config){
 async function autoUpdateFirmware(){
   var selected=getSelectedReleaseMeta();
   var plan=getSelectedReleaseInstallPlan(selected);
-  var blocked=otaBusy?'Another update is already running. Wait for completion.':getAutoUpdateBlockedReason('Automatic update',selected,plan);
+  var blocked=otaBusy?'Firmware update in progress — please wait.':getAutoUpdateBlockedReason('Automatic update',selected,plan);
   var firmwareInfo=getReleaseDownloadInfo(selected,'firmware');
   var spiffsInfo=getReleaseDownloadInfo(selected,'spiffs');
   if(blocked){
@@ -5031,7 +5107,7 @@ async function autoUpdateFirmware(){
 }
 
 async function uploadSelectedUpdatePair(){
-  var blocked=otaBusy?'Another update is already running. Wait for completion.':otaUploadUnavailableReason('Manual update');
+  var blocked=otaBusy?'Firmware update in progress — please wait.':otaUploadUnavailableReason('Manual update');
   if(blocked){
     ss('manual-ota-status','err',blocked);
     return;
@@ -5064,7 +5140,7 @@ async function uploadSelectedUpdatePair(){
 }
 
 async function uploadSingleFirmware(){
-  var blocked=otaBusy?'Another update is already running. Wait for completion.':otaUploadUnavailableReason('Single firmware upload');
+  var blocked=otaBusy?'Firmware update in progress — please wait.':otaUploadUnavailableReason('Single firmware upload');
   if(blocked){ss('adv-ota-status','err',blocked);return;}
   var fwFile=document.getElementById('adv-fw').files[0];
   if(!fwFile){ss('adv-ota-status','err','Select a firmware .bin file first.');return;}
@@ -5077,7 +5153,7 @@ async function uploadSingleFirmware(){
 }
 
 async function uploadSingleSpiffs(){
-  var blocked=otaBusy?'Another update is already running. Wait for completion.':otaUploadUnavailableReason('Single filesystem upload');
+  var blocked=otaBusy?'Firmware update in progress — please wait.':otaUploadUnavailableReason('Single filesystem upload');
   if(blocked){ss('adv-ota-status','err',blocked);return;}
   var spiffsFile=document.getElementById('adv-spiffs').files[0];
   if(!spiffsFile){ss('adv-ota-status','err','Select a filesystem .bin file first.');return;}

--- a/source/ESPEED32/data/ui/index.html
+++ b/source/ESPEED32/data/ui/index.html
@@ -1356,8 +1356,8 @@ var telemetryPanelPinned=false;
 var telemetryRedrawQueued=false;
 var telemetryConfigSnapshot=null;
 var telemetryFetchAbortController=null;
-var TELEMETRY_WIFI_LIVE_LIMIT=48;
-var TELEMETRY_WIFI_TAIL_SAMPLES=128;
+var TELEMETRY_WIFI_LIVE_LIMIT=32;
+var TELEMETRY_WIFI_TAIL_SAMPLES=96;
 var TELEMETRY_WIFI_MAX_FETCH_LOOPS=4;
 var TELEMETRY_USB_MAX_FETCH_LOOPS=20;
 var LAP_OVERLAY_SOURCE_NONE='none';
@@ -4165,6 +4165,7 @@ function updateFirmwareUiState(){
 }
 
 function setUsbReadyState(ready,msg){
+  var hadPolling=!!telemetryPollTimer;
   usbReady=!!ready;
   var b=document.getElementById('ucb');
   if(b && usb){
@@ -4173,9 +4174,11 @@ function setUsbReadyState(ready,msg){
   updateDocsLinkState();
   updateFirmwareUiState();
   updateReleaseInfoUi();
-  if(usbReady) startTelemetryPollingIfAvailable(true);
-  else if(infoLoadedFromApi) startTelemetryPollingIfAvailable(false);
-  else stopTelemetryPolling();
+  if(!usbReady && !infoLoadedFromApi){
+    stopTelemetryPolling();
+  }else if(hadPolling){
+    startTelemetryPollingIfAvailable(false);
+  }
   updateTelemetryUiState();
   updateTelemetryMetrics();
   scheduleTelemetryPlotRedraw();
@@ -4231,9 +4234,10 @@ async function loadInfoFromUsb(){
 }
 
 async function loadInfo(){
+  var hadPolling=!!telemetryPollTimer;
   var apiOk=false;
   try{
-    var r=await fetch('/api/info',{cache:'no-store'});
+    var r=await telemetryFetchWithTimeout('/api/info',{cache:'no-store'},6000);
     if(r.ok){
       var j=await r.json();
       infoLoadedFromApi=true;
@@ -4246,7 +4250,9 @@ async function loadInfo(){
   applyHostedMode();
   applyInfo();
   if(apiOk){
-    startTelemetryPollingIfAvailable(true);
+    if(hadPolling){
+      startTelemetryPollingIfAvailable(false);
+    }
   }else{
     stopTelemetryPolling();
   }
@@ -4283,6 +4289,7 @@ async function ws(s){
 }
 
 async function resetUsbToDisconnected(showStatus,statusType,statusMsg){
+  var hadPolling=!!telemetryPollTimer;
   usb=false;
   usbReady=false;
   infoLoadedFromUsb=false;
@@ -4311,8 +4318,8 @@ async function resetUsbToDisconnected(showStatus,statusType,statusMsg){
     telemetrySessionId=0;
     telemetryPersistentError='';
     lapOverlayRefreshFromCurrentTelemetry(true);
-  }else{
-    startTelemetryPollingIfAvailable(true);
+  }else if(hadPolling){
+    startTelemetryPollingIfAvailable(false);
   }
   updateTelemetryUiState();
   updateTelemetryMetrics();

--- a/source/ESPEED32/data/ui/index.html
+++ b/source/ESPEED32/data/ui/index.html
@@ -629,11 +629,32 @@ form{margin:0}
 }
 .progress-head{
   display:flex;
+  align-items:flex-start;
+  flex-wrap:wrap;
   justify-content:space-between;
   gap:10px;
   font-size:12px;
   color:var(--progress-head);
   margin-bottom:6px;
+}
+.update-panel,
+.update-actions,
+.progress-wrap,
+.progress-head,
+.progress-head span{
+  min-width:0;
+}
+.update-panel .tiny,
+.update-panel .warn,
+.progress-head span{
+  overflow-wrap:anywhere;
+  word-break:break-word;
+}
+.progress-head span:first-child{
+  flex:1 1 180px;
+}
+.progress-head span:last-child{
+  flex:0 0 auto;
 }
 .progress-track{
   width:100%;
@@ -1124,8 +1145,8 @@ form{margin:0}
 <button id="btn-telemetry-refresh" class="btn doc" type="button" onclick="telemetryRefresh()">Refresh Status</button>
 </div>
 <div class="telemetry-actions telemetry-secondary-actions">
-<a id="btn-telemetry-export-csv" class="btn dl" href="/api/telemetry/export.csv" download="espeed32-telemetry.csv">Export CSV</a>
-<a id="btn-telemetry-export-json" class="btn ota" href="/api/telemetry/export.json" download="espeed32-telemetry.json">Export JSON</a>
+<a id="btn-telemetry-export-csv" class="btn dl" href="#" download="espeed32-telemetry.csv">Export CSV</a>
+<a id="btn-telemetry-export-json" class="btn ota" href="#" download="espeed32-telemetry.json">Export JSON</a>
 </div>
 <div class="telemetry-config">
 <div class="row">
@@ -1356,8 +1377,11 @@ var telemetryPanelPinned=false;
 var telemetryRedrawQueued=false;
 var telemetryConfigSnapshot=null;
 var telemetryFetchAbortController=null;
-var TELEMETRY_WIFI_LIVE_LIMIT=32;
-var TELEMETRY_WIFI_TAIL_SAMPLES=96;
+var telemetryPollingPausedByError=false;
+var telemetryLastSuccessAtMs=0;
+var telemetryLastErrorAtMs=0;
+var TELEMETRY_WIFI_LIVE_LIMIT=16;
+var TELEMETRY_WIFI_TAIL_SAMPLES=64;
 var TELEMETRY_WIFI_MAX_FETCH_LOOPS=4;
 var TELEMETRY_USB_MAX_FETCH_LOOPS=20;
 var LAP_OVERLAY_SOURCE_NONE='none';
@@ -2558,7 +2582,11 @@ async function telemetryLoadConfigSnapshot(){
   if(telemetryConfigSnapshot) return telemetryConfigSnapshot;
   if(telemetryUsesUsb()){
     telemetryConfigSnapshot=await usbReadJsonResponse('TCONFIG',15000,120000);
+    return telemetryConfigSnapshot;
   }
+  var resp=await telemetryFetchWithTimeout('/api/telemetry/config',{cache:'no-store'},10000);
+  if(!resp.ok) throw new Error('Telemetry config unavailable (HTTP '+resp.status+')');
+  telemetryConfigSnapshot=await resp.json();
   return telemetryConfigSnapshot;
 }
 
@@ -2601,36 +2629,35 @@ function telemetryDownloadBlob(blob,fileName){
   },1000);
 }
 
-async function telemetryFetchExportBlob(format){
-  var url=(format==='csv')?'/api/telemetry/export.csv':'/api/telemetry/export.json';
-  var resp=await fetch(url,{cache:'no-store'});
-  if(!resp.ok){
-    var errText='';
-    try{ errText=await resp.text(); }catch(_){}
-    throw new Error(errText||('Telemetry export failed (HTTP '+resp.status+')'));
-  }
-  return await resp.blob();
-}
-
 async function telemetryCollectExportData(){
   var snapshot=null;
-  if(telemetryUsesUsb()){
+  try{
     snapshot=await telemetryLoadConfigSnapshot();
+  }catch(_){
+    snapshot=null;
   }
 
   var samples=[];
   var events=[];
   var restarts=0;
+  var batchLimit=telemetryUsesUsb()?96:TELEMETRY_WIFI_LIVE_LIMIT;
+  var targetSamples=Math.max(
+    1,
+    Number((telemetryStatus&&telemetryStatus.storedCount)||0),
+    Number((telemetryStatus&&telemetryStatus.capacity)||0)
+  );
+  var maxBatches=Math.max(32,Math.ceil(targetSamples/Math.max(1,batchLimit))+16);
 
   while(restarts<3){
     var after=0;
     var sessionId=0;
     var restarted=false;
+    var sawEvents=false;
     samples=[];
     events=[];
 
-    for(var safety=0;safety<32;safety++){
-      var data=await telemetryFetchLiveTransport(after,256);
+    for(var safety=0;safety<maxBatches;safety++){
+      var data=await telemetryFetchLiveTransport(after,batchLimit);
       if(!data || !data.ok) throw new Error('Telemetry export failed');
       if(!data.hasData) return {status:data,snapshot:snapshot,samples:[],events:[]};
 
@@ -2641,12 +2668,25 @@ async function telemetryCollectExportData(){
       }
 
       sessionId=Number(data.sessionId||0);
-      events=Array.isArray(data.events)?data.events:[];
+      targetSamples=Math.max(
+        targetSamples,
+        Number(data.storedCount||0),
+        Number(data.capacity||0)
+      );
+      maxBatches=Math.max(maxBatches,Math.ceil(targetSamples/Math.max(1,batchLimit))+16);
+      if(!sawEvents && Array.isArray(data.events) && data.events.length){
+        events=data.events.slice();
+        sawEvents=true;
+      }
       if(Array.isArray(data.samples)){
+        var beforeCount=samples.length;
         data.samples.forEach(function(sample){
           samples.push(sample);
           after=Number(sample[TELEMETRY_FIELDS.SEQ]||after);
         });
+        if(data.hasMore && samples.length===beforeCount){
+          throw new Error('Telemetry export stalled before all samples were fetched');
+        }
       }
 
       if(!data.hasMore){
@@ -2741,30 +2781,25 @@ async function telemetryExport(format){
 
   try{
     var baseName=telemetryGetExportBaseName();
-    var exportData=null;
-    if(telemetryUsesUsb()){
-      exportData=await telemetryCollectExportData();
-      if(!exportData.samples.length){
-        throw new Error('No telemetry data available');
-      }
-
-      if(format==='csv'){
-        telemetryDownloadBlob(
-          new Blob([telemetryBuildCsvExport(exportData.samples,exportData.snapshot)],{type:'text/csv;charset=utf-8'}),
-          baseName+'.csv'
-        );
-      }else{
-        telemetryDownloadBlob(
-          new Blob([JSON.stringify(telemetryBuildJsonExport(exportData.samples,exportData.status,exportData.snapshot,exportData.events),null,2)],{type:'application/json;charset=utf-8'}),
-          baseName+'.json'
-        );
-      }
-
-      telemetryStatus=exportData.status||telemetryStatus;
-      telemetryEvents=Array.isArray(exportData.events)?exportData.events:telemetryEvents;
-    }else{
-      telemetryDownloadBlob(await telemetryFetchExportBlob(format),baseName+(format==='csv'?'.csv':'.json'));
+    var exportData=await telemetryCollectExportData();
+    if(!exportData.samples.length){
+      throw new Error('No telemetry data available');
     }
+
+    if(format==='csv'){
+      telemetryDownloadBlob(
+        new Blob([telemetryBuildCsvExport(exportData.samples,exportData.snapshot)],{type:'text/csv;charset=utf-8'}),
+        baseName+'.csv'
+      );
+    }else{
+      telemetryDownloadBlob(
+        new Blob([JSON.stringify(telemetryBuildJsonExport(exportData.samples,exportData.status,exportData.snapshot,exportData.events),null,2)],{type:'application/json;charset=utf-8'}),
+        baseName+'.json'
+      );
+    }
+
+    telemetryStatus=exportData.status||telemetryStatus;
+    telemetryEvents=Array.isArray(exportData.events)?exportData.events:telemetryEvents;
     telemetryPersistentError='';
     updateTelemetryMetrics();
     drawTelemetryPlot();
@@ -2785,10 +2820,10 @@ function normalizeTelemetryError(err){
     return 'Telemetry is unavailable on this page.';
   }
   if(message==='Load failed'){
-    return 'Telemetry live update dropped. The controller WiFi page is still connected, but the live telemetry response was too heavy or interrupted.';
+    return 'Telemetry live update dropped. Live polling was paused so the page does not overload the controller. Press Refresh Status to retry.';
   }
   if(message==='Telemetry request timed out'){
-    return 'Telemetry live update timed out. The controller stayed online, but the live response did not finish in time.';
+    return 'Telemetry live update timed out. Live polling was paused so the page does not overload the controller. Press Refresh Status to retry.';
   }
   if(message==='Telemetry request cancelled'){
     return 'Telemetry was paused so the firmware update could start cleanly.';
@@ -2839,6 +2874,8 @@ function startTelemetryPollingIfAvailable(refreshNow){
   stopTelemetryPolling();
   if(otaBusy && !telemetryUsesUsb()) return;
   if(!telemetryAvailable()) return;
+  if(telemetryPollingPausedByError && !refreshNow) return;
+  if(refreshNow) telemetryPollingPausedByError=false;
   if(refreshNow) syncTelemetryHistory(true,true);
   var intervalMs=telemetryUsesUsb()?telemetryPollIntervalMs:Math.max(1000,telemetryPollIntervalMs);
   telemetryPollTimer=setInterval(function(){ syncTelemetryHistory(false,true); },intervalMs);
@@ -2946,6 +2983,8 @@ function telemetryBuildEventLabel(event){
 function updateTelemetryAvailabilityNote(){
   var note=document.getElementById('telemetry-note');
   if(!note) return;
+  var recoveredSinceError=telemetryLastSuccessAtMs>0 && telemetryLastSuccessAtMs>=telemetryLastErrorAtMs;
+  var status=telemetryStatus||{};
   if(telemetryUsesUsb()){
     note.style.display='none';
     note.textContent='';
@@ -2955,7 +2994,7 @@ function updateTelemetryAvailabilityNote(){
   }else if(!infoLoadedFromApi){
     note.style.display='block';
     note.textContent='Telemetry becomes available when this UI is served by the controller WiFi API, or when USB WebSerial is connected.';
-  }else if(telemetryPersistentError){
+  }else if(telemetryPersistentError && !recoveredSinceError && !(status.loggingActive && telemetrySamples.length>0)){
     note.style.display='block';
     note.textContent=telemetryPersistentError;
   }else{
@@ -3040,8 +3079,8 @@ function updateTelemetryUiState(){
     btn.classList.toggle('disabled',!!btn.disabled);
   });
 
-  setAnchorDisabled('btn-telemetry-export-csv',!available || !hasData,telemetryUsesUsb()?'#':'/api/telemetry/export.csv');
-  setAnchorDisabled('btn-telemetry-export-json',!available || !hasData,telemetryUsesUsb()?'#':'/api/telemetry/export.json');
+  setAnchorDisabled('btn-telemetry-export-csv',!available || !hasData,'#');
+  setAnchorDisabled('btn-telemetry-export-json',!available || !hasData,'#');
   updateTelemetryAvailabilityNote();
   updateTelemetryLayout();
 }
@@ -3917,6 +3956,8 @@ async function syncTelemetryHistory(reset,silent,persistError){
     }
 
     telemetryPersistentError='';
+    telemetryPollingPausedByError=false;
+    telemetryLastSuccessAtMs=Date.now();
     lapOverlayRefreshFromCurrentTelemetry(true);
     updateTelemetryMetrics();
     drawTelemetryPlot();
@@ -3926,6 +3967,11 @@ async function syncTelemetryHistory(reset,silent,persistError){
   }catch(e){
     var errorText=normalizeTelemetryError(e);
     telemetryPersistentError=(persistError===false)?'':errorText;
+    telemetryLastErrorAtMs=Date.now();
+    if(!telemetryUsesUsb() && errorText!=='Telemetry was paused so the firmware update could start cleanly.'){
+      telemetryPollingPausedByError=true;
+      stopTelemetryPolling();
+    }
     if(!silent){
       ss('tst','err',errorText);
     }
@@ -3946,6 +3992,7 @@ async function telemetryPostAction(url,successText,resetHistory){
   telemetryPanelPinned=true;
   var hadPolling=!!telemetryPollTimer;
   stopTelemetryPolling();
+  telemetryPollingPausedByError=false;
   telemetryUiBusy=true;
   updateTelemetryUiState();
   try{
@@ -3976,6 +4023,7 @@ async function telemetryPostAction(url,successText,resetHistory){
 
 async function telemetryRefresh(){
   telemetryPanelPinned=true;
+  telemetryPollingPausedByError=false;
   await syncTelemetryHistory(true,false,false);
 }
 
@@ -4036,13 +4084,13 @@ function initTelemetryUi(){
 
 function otaUploadUnavailableReason(label){
   if(hostedMode){
-    return label+' unavailable in hosted mode. Open controller WiFi page to upload.';
+    return label+' unavailable in hosted mode. Open the live controller page to upload.';
   }
   if(usb){
-    return label+' unavailable while USB WebSerial is connected. Disconnect USB to use WiFi OTA.';
+    return label+' unavailable while USB WebSerial is connected. Disconnect USB to continue.';
   }
   if(!infoLoadedFromApi){
-    return label+' requires the live controller WiFi page.';
+    return label+' requires the live controller page.';
   }
   return '';
 }
@@ -4051,7 +4099,7 @@ function autoUpdateUnavailableReason(label,kind){
   var baseReason=otaUploadUnavailableReason(label);
   if(baseReason) return baseReason;
   if(Number(info.portalMode||0)!==2){
-    return label+' requires Client mode with internet access on this device.';
+    return label+' requires Client mode with internet access.';
   }
   return '';
 }
@@ -5231,6 +5279,14 @@ if(typeof window!=='undefined'){
   window.addEventListener('online',updateFirmwareUiState);
   window.addEventListener('offline',updateFirmwareUiState);
   window.addEventListener('resize',scheduleTelemetryPlotRedraw);
+  window.addEventListener('pagehide',function(){
+    cancelTelemetryFetches();
+    stopTelemetryPolling();
+  });
+  window.addEventListener('beforeunload',function(){
+    cancelTelemetryFetches();
+    stopTelemetryPolling();
+  });
 }
 loadInfo();
 loadLatestReleaseInfo();

--- a/source/ESPEED32/data/ui/index.html
+++ b/source/ESPEED32/data/ui/index.html
@@ -1355,7 +1355,7 @@ var telemetryFetchBusy=false;
 var telemetryUiBusy=false;
 var telemetryPollTimer=null;
 var telemetryPollIntervalMs=250;
-var telemetryLastError='';
+var telemetryPersistentError='';
 var telemetryRedrawQueued=false;
 var telemetryConfigSnapshot=null;
 var LAP_OVERLAY_SOURCE_NONE='none';
@@ -2498,7 +2498,8 @@ async function telemetryFetchLiveTransport(after,limit){
     var usbLimit=Math.min(Number(limit||256),96);
     return await usbReadJsonResponse('TLIVE '+String(after||0)+' '+String(usbLimit),15000,120000);
   }
-  var resp=await fetch('/api/telemetry/live?after='+encodeURIComponent(after||0)+'&limit='+encodeURIComponent(limit||256),{cache:'no-store'});
+  var wifiLimit=Math.min(Number(limit||256),120);
+  var resp=await fetch('/api/telemetry/live?after='+encodeURIComponent(after||0)+'&limit='+encodeURIComponent(wifiLimit),{cache:'no-store'});
   if(!resp.ok) throw new Error('Telemetry unavailable (HTTP '+resp.status+')');
   var data=await resp.json();
   if(!data || !data.ok) throw new Error((data&&data.error)?data.error:'Telemetry fetch failed');
@@ -2727,13 +2728,12 @@ async function telemetryExport(format){
     }else{
       telemetryDownloadBlob(await telemetryFetchExportBlob(format),baseName+(format==='csv'?'.csv':'.json'));
     }
-    telemetryLastError='';
+    telemetryPersistentError='';
     updateTelemetryMetrics();
     drawTelemetryPlot();
     ss('tst','ok','Telemetry '+String(format||'').toUpperCase()+' exported');
   }catch(e){
-    telemetryLastError=normalizeTelemetryError(e);
-    ss('tst','err',telemetryLastError);
+    ss('tst','err',normalizeTelemetryError(e));
   }finally{
     telemetryUiBusy=false;
     updateTelemetryUiState();
@@ -2908,9 +2908,9 @@ function updateTelemetryAvailabilityNote(){
   }else if(!infoLoadedFromApi){
     note.style.display='block';
     note.textContent='Telemetry becomes available when this UI is served by the controller WiFi API, or when USB WebSerial is connected.';
-  }else if(telemetryLastError){
+  }else if(telemetryPersistentError){
     note.style.display='block';
-    note.textContent=telemetryLastError;
+    note.textContent=telemetryPersistentError;
   }else{
     note.style.display='none';
     note.textContent='';
@@ -3783,7 +3783,7 @@ function initLapOverlayUi(){
   drawLapOverlayPlot();
 }
 
-async function syncTelemetryHistory(reset,silent){
+async function syncTelemetryHistory(reset,silent,persistError){
   if(otaBusy && !telemetryUsesUsb()){
     stopTelemetryPolling();
     return;
@@ -3795,7 +3795,7 @@ async function syncTelemetryHistory(reset,silent){
     telemetryEvents=[];
     telemetryAfterSeq=0;
     telemetrySessionId=0;
-    telemetryLastError='';
+    telemetryPersistentError='';
     lapOverlayRefreshFromCurrentTelemetry(true);
     updateTelemetryUiState();
     updateTelemetryMetrics();
@@ -3852,7 +3852,7 @@ async function syncTelemetryHistory(reset,silent){
       safety++;
     }
 
-    telemetryLastError='';
+    telemetryPersistentError='';
     lapOverlayRefreshFromCurrentTelemetry(true);
     updateTelemetryMetrics();
     drawTelemetryPlot();
@@ -3860,9 +3860,10 @@ async function syncTelemetryHistory(reset,silent){
       ss('tst','ok','Telemetry refreshed');
     }
   }catch(e){
-    telemetryLastError=normalizeTelemetryError(e);
+    var errorText=normalizeTelemetryError(e);
+    telemetryPersistentError=(persistError===false)?'':errorText;
     if(!silent){
-      ss('tst','err',telemetryLastError);
+      ss('tst','err',errorText);
     }
   }finally{
     telemetryFetchBusy=false;
@@ -3894,15 +3895,14 @@ async function telemetryPostAction(url,successText,resetHistory){
       telemetrySessionId=0;
       telemetryConfigSnapshot=null;
     }
-    telemetryLastError='';
+    telemetryPersistentError='';
     updateTelemetryUiState();
     updateTelemetryMetrics();
     drawTelemetryPlot();
     await syncTelemetryHistory(!!resetHistory,true);
     ss('tst','ok',successText||data.message||'Done');
   }catch(e){
-    telemetryLastError=normalizeTelemetryError(e);
-    ss('tst','err',telemetryLastError);
+    ss('tst','err',normalizeTelemetryError(e));
   }finally{
     telemetryUiBusy=false;
     updateTelemetryUiState();
@@ -3913,7 +3913,7 @@ async function telemetryPostAction(url,successText,resetHistory){
 }
 
 async function telemetryRefresh(){
-  await syncTelemetryHistory(true,false);
+  await syncTelemetryHistory(true,false,false);
 }
 
 async function telemetryStart(){
@@ -4248,7 +4248,7 @@ async function resetUsbToDisconnected(showStatus,statusType,statusMsg){
     telemetryEvents=[];
     telemetryAfterSeq=0;
     telemetrySessionId=0;
-    telemetryLastError='';
+    telemetryPersistentError='';
     lapOverlayRefreshFromCurrentTelemetry(true);
   }else{
     startTelemetryPollingIfAvailable(true);

--- a/source/ESPEED32/data/ui/index.html
+++ b/source/ESPEED32/data/ui/index.html
@@ -2586,6 +2586,17 @@ async function telemetryFetchLiveTransport(after,limit){
   return data;
 }
 
+async function telemetryFetchEventsTransport(){
+  if(telemetryUsesUsb()){
+    return await usbReadJsonResponse('TEVENTS',15000,120000);
+  }
+  var resp=await telemetryFetchWithTimeout('/api/telemetry/events',{cache:'no-store'},10000);
+  if(!resp.ok) throw new Error('Telemetry events unavailable (HTTP '+resp.status+')');
+  var data=await resp.json();
+  if(!data || !data.ok) throw new Error((data&&data.error)?data.error:'Telemetry events fetch failed');
+  return data;
+}
+
 async function telemetryPostTransport(action){
   if(telemetryUsesUsb()){
     return await usbReadJsonResponse(action,15000,40000);
@@ -2648,7 +2659,22 @@ function telemetryDownloadBlob(blob,fileName){
   },1000);
 }
 
-async function telemetryCollectExportData(){
+function telemetryEventsWereTruncated(status){
+  return !!(status && (status.eventsTruncated || status.eventTruncated));
+}
+
+function telemetryFilterEventsForSnapshot(events,targetLatestEventId,targetLatestSeq){
+  if(!Array.isArray(events)) return [];
+  return events.filter(function(event){
+    var eventId=Number((event&&event.id)||0);
+    var sampleSeq=Number((event&&event.sampleSeq)||0);
+    if(targetLatestEventId>0 && eventId>targetLatestEventId) return false;
+    if(targetLatestSeq>0 && sampleSeq>targetLatestSeq) return false;
+    return true;
+  });
+}
+
+async function telemetryCollectExportData(includeEvents){
   var snapshot=null;
   try{
     snapshot=await telemetryLoadConfigSnapshot();
@@ -2656,60 +2682,69 @@ async function telemetryCollectExportData(){
     snapshot=null;
   }
 
-  var samples=[];
-  var events=[];
   var restarts=0;
   var batchLimit=telemetryUsesUsb()?TELEMETRY_USB_LIVE_LIMIT:TELEMETRY_WIFI_LIVE_LIMIT;
-  var targetSamples=Math.max(
-    1,
-    Number((telemetryStatus&&telemetryStatus.storedCount)||0),
-    Number((telemetryStatus&&telemetryStatus.capacity)||0)
-  );
-  var maxBatches=Math.max(32,Math.ceil(targetSamples/Math.max(1,batchLimit))+16);
 
   while(restarts<3){
+    var statusSeed=await telemetryFetchStatusTransport();
+    if(!statusSeed || !statusSeed.hasData){
+      return {status:statusSeed||null,snapshot:snapshot,samples:[],events:[]};
+    }
+
+    var targetSessionId=Number(statusSeed.sessionId||0);
+    var targetLatestSeq=Number(statusSeed.latestSeq||0);
+    var targetLatestEventId=Number(statusSeed.latestEventId||0);
+    var targetSamples=Math.max(
+      1,
+      Number(statusSeed.storedCount||0),
+      Number(statusSeed.capacity||0)
+    );
+    var maxBatches=Math.max(32,Math.ceil(targetSamples/Math.max(1,batchLimit))+16);
     var after=0;
-    var sessionId=0;
     var restarted=false;
-    var sawEvents=false;
-    samples=[];
-    events=[];
+    var samples=[];
+    var fallbackEvents=[];
+    var fallbackEventsTruncated=false;
 
     for(var safety=0;safety<maxBatches;safety++){
       var data=await telemetryFetchLiveTransport(after,batchLimit);
       if(!data || !data.ok) throw new Error('Telemetry export failed');
       if(!data.hasData) return {status:data,snapshot:snapshot,samples:[],events:[]};
 
-      if((sessionId && Number(data.sessionId||0)!==sessionId) || (data.truncated && after!==0)){
+      if(Number(data.sessionId||0)!==targetSessionId || (data.truncated && after!==0)){
         restarts++;
         restarted=true;
         break;
       }
 
-      sessionId=Number(data.sessionId||0);
-      targetSamples=Math.max(
-        targetSamples,
-        Number(data.storedCount||0),
-        Number(data.capacity||0)
-      );
-      maxBatches=Math.max(maxBatches,Math.ceil(targetSamples/Math.max(1,batchLimit))+16);
-      if(!sawEvents && Array.isArray(data.events) && data.events.length){
-        events=data.events.slice();
-        sawEvents=true;
+      if(after===0 && Array.isArray(data.events) && data.events.length){
+        fallbackEvents=data.events.slice();
+        fallbackEventsTruncated=telemetryEventsWereTruncated(data);
       }
+
+      var reachedTarget=false;
       if(Array.isArray(data.samples)){
         var beforeCount=samples.length;
         data.samples.forEach(function(sample){
+          var seq=Number(sample[TELEMETRY_FIELDS.SEQ]||0);
+          if(seq<=0) return;
+          if(targetLatestSeq>0 && seq>targetLatestSeq){
+            reachedTarget=true;
+            return;
+          }
           samples.push(sample);
-          after=Number(sample[TELEMETRY_FIELDS.SEQ]||after);
+          after=seq;
+          if(targetLatestSeq>0 && seq>=targetLatestSeq){
+            reachedTarget=true;
+          }
         });
-        if(data.hasMore && samples.length===beforeCount){
+        if(data.hasMore && samples.length===beforeCount && !reachedTarget){
           throw new Error('Telemetry export stalled before all samples were fetched');
         }
       }
 
-      if(!data.hasMore){
-        return {status:data,snapshot:snapshot,samples:samples,events:events};
+      if(reachedTarget || !data.hasMore){
+        break;
       }
     }
 
@@ -2717,7 +2752,39 @@ async function telemetryCollectExportData(){
       continue;
     }
 
-    throw new Error('Telemetry export exceeded expected batch count');
+    if(targetLatestSeq>0 && after<targetLatestSeq){
+      restarts++;
+      continue;
+    }
+
+    var events=[];
+    var eventsTruncated=false;
+    if(includeEvents && targetLatestEventId>0){
+      try{
+        var eventsData=await telemetryFetchEventsTransport();
+        if(Number(eventsData.sessionId||0)!==targetSessionId){
+          restarts++;
+          continue;
+        }
+        events=telemetryFilterEventsForSnapshot(eventsData.events,targetLatestEventId,targetLatestSeq);
+        eventsTruncated=telemetryEventsWereTruncated(eventsData);
+      }catch(e){
+        events=telemetryFilterEventsForSnapshot(fallbackEvents,targetLatestEventId,targetLatestSeq);
+        eventsTruncated=fallbackEventsTruncated;
+        if(!events.length){
+          throw e;
+        }
+      }
+    }
+
+    var exportStatus=Object.assign({},statusSeed,{
+      storedCount:samples.length,
+      latestSeq:targetLatestSeq,
+      latestEventId:targetLatestEventId,
+      eventTruncated:!!eventsTruncated,
+      eventsTruncated:!!eventsTruncated
+    });
+    return {status:exportStatus,snapshot:snapshot,samples:samples,events:events};
   }
 
   throw new Error('Telemetry export could not stabilize while logging. Stop logging and try again.');
@@ -2767,7 +2834,7 @@ function telemetryBuildJsonExport(samples,status,snapshot,events){
     sessionStartMs:Number((status && status.sessionStartMs)||0),
     sessionStartCarIndex:Number((status && status.sessionStartCarIndex)||0),
     configAtStart:snapshot||null,
-    eventsTruncated:!!(status && status.eventTruncated),
+    eventsTruncated:telemetryEventsWereTruncated(status),
     events:Array.isArray(events)?events:[],
     samples:samples.map(function(sample){
       return {
@@ -2800,7 +2867,7 @@ async function telemetryExport(format){
 
   try{
     var baseName=telemetryGetExportBaseName();
-    var exportData=await telemetryCollectExportData();
+    var exportData=await telemetryCollectExportData(format==='json');
     if(!exportData.samples.length){
       throw new Error('No telemetry data available');
     }

--- a/source/ESPEED32/data/ui/index.html
+++ b/source/ESPEED32/data/ui/index.html
@@ -3530,6 +3530,10 @@ function lapOverlayAnalyze(silent){
 }
 
 async function lapOverlayUseCurrentTelemetry(){
+  if(!telemetryAvailable()){
+    ss('lapst','err',telemetryUnavailableText());
+    return;
+  }
   lapOverlaySourceKind=LAP_OVERLAY_SOURCE_CURRENT;
   if(!telemetrySamples.length && telemetryAvailable()){
     try{
@@ -3537,8 +3541,12 @@ async function lapOverlayUseCurrentTelemetry(){
     }catch(_){}
   }
   lapOverlayRefreshFromCurrentTelemetry(false);
-  if(telemetryAvailable()){
+  var status=telemetryStatus||{};
+  var hasCurrentSource=!!(lapOverlaySamples.length || telemetrySamples.length || status.hasData || status.loggingActive);
+  if(hasCurrentSource && status.loggingActive){
     ss('lapst','ok','Using current telemetry buffer. Lap Overlay will update live while telemetry runs.');
+  }else if(hasCurrentSource){
+    ss('lapst','ok','Using current telemetry buffer.');
   }
 }
 

--- a/source/ESPEED32/data/ui/index.html
+++ b/source/ESPEED32/data/ui/index.html
@@ -5338,6 +5338,12 @@ document.getElementById('uf').onsubmit=async function(e){
 };
 
 document.getElementById('btn-fw-backup-modal-download').onclick=async function(){
+  try{
+    await pauseBackgroundActivityForOta(otaBackupPromptStatusId);
+  }catch(e){
+    ss(otaBackupPromptStatusId,'err',e.message);
+    return;
+  }
   await doBackup(otaBackupPromptStatusId);
   if(backupDownloadedThisSession) closeFirmwareBackupPrompt(true);
 };

--- a/source/ESPEED32/data/ui/index.html
+++ b/source/ESPEED32/data/ui/index.html
@@ -1644,7 +1644,7 @@ function renderControllerAbout(){
   }else if(infoLoadedFromUsb){
     note.textContent='Hosted copy: live controller details loaded over USB WebSerial.';
   }else if(hostedMode){
-    note.textContent='Hosted copy: connect to controller WiFi or USB to load live hardware, MAC, build, and network details.';
+    note.textContent='Hosted copy: connect to controller WiFi or USB to load this.';
   }else{
     note.textContent='Loading controller details...';
   }

--- a/source/ESPEED32/data/ui/public.html
+++ b/source/ESPEED32/data/ui/public.html
@@ -515,7 +515,13 @@ function hostedDocsPath(){
 }
 
 function isLikelyDeviceHost(h){
-  return h==='192.168.4.1' || h==='localhost' || h==='127.0.0.1' || /\.local$/i.test(h||'');
+  if(!h) return false;
+  if(h==='localhost' || h==='127.0.0.1' || /\.local$/i.test(h)) return true;
+  /* RFC1918 private ranges — any page served from a private IP is on the device directly */
+  if(/^10\./.test(h)) return true;
+  if(/^192\.168\./.test(h)) return true;
+  if(/^172\.(1[6-9]|2\d|3[01])\./.test(h)) return true;
+  return false;
 }
 
 async function isControllerHostedPage(){

--- a/source/ESPEED32/data/ui/release.json
+++ b/source/ESPEED32/data/ui/release.json
@@ -1,3 +1,3 @@
 {
-  "spiffsRelease": "6.10"
+  "spiffsRelease": "6.11"
 }

--- a/source/ESPEED32/slot_ESC.h
+++ b/source/ESPEED32/slot_ESC.h
@@ -17,7 +17,7 @@
 
 /* Firmware Version */
 #define SW_MAJOR_VERSION 6
-#define SW_MINOR_VERSION 10
+#define SW_MINOR_VERSION 11
 #define SW_PATCH_VERSION 0
 
 /* Stored Variable Version */

--- a/source/ESPEED32/telemetry_logging.cpp
+++ b/source/ESPEED32/telemetry_logging.cpp
@@ -6,6 +6,8 @@
 static portMUX_TYPE g_telemetryMux = portMUX_INITIALIZER_UNLOCKED;
 static TelemetrySample* g_telemetrySamples = nullptr;
 static TelemetryEvent* g_telemetryEvents = nullptr;
+static uint16_t g_telemetrySampleCapacity = 0;
+static uint16_t g_telemetryEventCapacity = 0;
 static TelemetryConfigSnapshot g_telemetryConfigSnapshot;
 static bool g_telemetryConfigValid = false;
 static bool g_telemetryLoggingActive = false;
@@ -31,8 +33,102 @@ static void telemetrySetLastStartError(const char* msg) {
   g_telemetryLastStartError[sizeof(g_telemetryLastStartError) - 1U] = '\0';
 }
 
+static uint16_t telemetryAlignCapacityDown(uint16_t value, uint16_t step, uint16_t minimum) {
+  if (value <= minimum) {
+    return minimum;
+  }
+  if (step == 0U) {
+    return value;
+  }
+  uint16_t aligned = (uint16_t)((value / step) * step);
+  if (aligned < minimum) {
+    aligned = minimum;
+  }
+  return aligned;
+}
+
+static uint16_t telemetryStepCapacityDown(uint16_t value, uint16_t step, uint16_t minimum) {
+  if (value <= minimum) {
+    return minimum;
+  }
+  if (step == 0U || value <= (uint16_t)(minimum + step)) {
+    return minimum;
+  }
+  return (uint16_t)(value - step);
+}
+
+static TelemetrySample* telemetryAllocateSampleBuffer(uint16_t* outCapacity) {
+  if (outCapacity == nullptr) {
+    return nullptr;
+  }
+
+  *outCapacity = 0U;
+
+  size_t freeHeap = ESP.getFreeHeap();
+  size_t budgetBytes = 0U;
+  if (freeHeap > TELEMETRY_HEAP_RESERVE_BYTES) {
+    budgetBytes = freeHeap - TELEMETRY_HEAP_RESERVE_BYTES;
+  } else if (freeHeap > TELEMETRY_HEAP_MIN_RESERVE_BYTES) {
+    budgetBytes = freeHeap - TELEMETRY_HEAP_MIN_RESERVE_BYTES;
+  } else {
+    budgetBytes = freeHeap / 4U;
+  }
+
+  uint32_t requestedCapacity = (uint32_t)(budgetBytes / sizeof(TelemetrySample));
+  if (requestedCapacity > TELEMETRY_BUFFER_CAPACITY) {
+    requestedCapacity = TELEMETRY_BUFFER_CAPACITY;
+  }
+  if (requestedCapacity < TELEMETRY_BUFFER_MIN_CAPACITY) {
+    requestedCapacity = TELEMETRY_BUFFER_MIN_CAPACITY;
+  }
+
+  uint16_t capacity = telemetryAlignCapacityDown((uint16_t)requestedCapacity,
+                                                 TELEMETRY_BUFFER_ALLOC_STEP,
+                                                 TELEMETRY_BUFFER_MIN_CAPACITY);
+  while (capacity >= TELEMETRY_BUFFER_MIN_CAPACITY) {
+    TelemetrySample* buffer = (TelemetrySample*)malloc(sizeof(TelemetrySample) * capacity);
+    if (buffer != nullptr) {
+      *outCapacity = capacity;
+      return buffer;
+    }
+    if (capacity == TELEMETRY_BUFFER_MIN_CAPACITY) {
+      break;
+    }
+    capacity = telemetryStepCapacityDown(capacity,
+                                         TELEMETRY_BUFFER_ALLOC_STEP,
+                                         TELEMETRY_BUFFER_MIN_CAPACITY);
+  }
+
+  return nullptr;
+}
+
+static TelemetryEvent* telemetryAllocateEventBuffer(uint16_t* outCapacity) {
+  if (outCapacity == nullptr) {
+    return nullptr;
+  }
+
+  *outCapacity = 0U;
+
+  uint16_t capacity = TELEMETRY_EVENT_BUFFER_CAPACITY;
+  while (capacity >= TELEMETRY_EVENT_BUFFER_MIN_CAPACITY) {
+    TelemetryEvent* buffer = (TelemetryEvent*)malloc(sizeof(TelemetryEvent) * capacity);
+    if (buffer != nullptr) {
+      *outCapacity = capacity;
+      return buffer;
+    }
+    if (capacity == TELEMETRY_EVENT_BUFFER_MIN_CAPACITY) {
+      break;
+    }
+    capacity = telemetryStepCapacityDown(capacity,
+                                         TELEMETRY_EVENT_BUFFER_ALLOC_STEP,
+                                         TELEMETRY_EVENT_BUFFER_MIN_CAPACITY);
+  }
+
+  return nullptr;
+}
+
 static uint32_t telemetryOldestSeqLocked() {
-  if (g_telemetryCount == 0 || g_telemetryNextSeq == 0) {
+  if (g_telemetryCount == 0 || g_telemetryNextSeq == 0 || g_telemetrySampleCapacity == 0U) {
     return 0;
   }
   return g_telemetryNextSeq - (uint32_t)g_telemetryCount;
@@ -46,7 +142,7 @@ static uint32_t telemetryLatestSeqLocked() {
 }
 
 static uint32_t telemetryOldestEventIdLocked() {
-  if (g_telemetryEventCount == 0 || g_telemetryNextEventId == 0) {
+  if (g_telemetryEventCount == 0 || g_telemetryNextEventId == 0 || g_telemetryEventCapacity == 0U) {
     return 0;
   }
   return g_telemetryNextEventId - (uint32_t)g_telemetryEventCount;
@@ -60,17 +156,17 @@ static uint32_t telemetryLatestEventIdLocked() {
 }
 
 static uint16_t telemetryOldestIndexLocked() {
-  if (g_telemetryCount == 0) {
+  if (g_telemetryCount == 0 || g_telemetrySampleCapacity == 0U) {
     return 0;
   }
-  return (uint16_t)((g_telemetryHead + TELEMETRY_BUFFER_CAPACITY - g_telemetryCount) % TELEMETRY_BUFFER_CAPACITY);
+  return (uint16_t)((g_telemetryHead + g_telemetrySampleCapacity - g_telemetryCount) % g_telemetrySampleCapacity);
 }
 
 static uint16_t telemetryOldestEventIndexLocked() {
-  if (g_telemetryEventCount == 0) {
+  if (g_telemetryEventCount == 0 || g_telemetryEventCapacity == 0U) {
     return 0;
   }
-  return (uint16_t)((g_telemetryEventHead + TELEMETRY_EVENT_BUFFER_CAPACITY - g_telemetryEventCount) % TELEMETRY_EVENT_BUFFER_CAPACITY);
+  return (uint16_t)((g_telemetryEventHead + g_telemetryEventCapacity - g_telemetryEventCount) % g_telemetryEventCapacity);
 }
 
 static uint16_t telemetryComputeCarParamChangeMask(const CarParam_type* before, const CarParam_type* after) {
@@ -102,7 +198,7 @@ static void telemetryRecordEventLocked(uint8_t type,
                                        uint8_t previousCarIndex,
                                        uint16_t changedMask,
                                        const CarParam_type* carParam) {
-  if (g_telemetryEvents == nullptr || carParam == nullptr || carIndex >= CAR_MAX_COUNT) {
+  if (g_telemetryEvents == nullptr || g_telemetryEventCapacity == 0U || carParam == nullptr || carIndex >= CAR_MAX_COUNT) {
     return;
   }
 
@@ -120,8 +216,8 @@ static void telemetryRecordEventLocked(uint8_t type,
   event.carParam = *carParam;
 
   g_telemetryEvents[g_telemetryEventHead] = event;
-  g_telemetryEventHead = (uint16_t)((g_telemetryEventHead + 1U) % TELEMETRY_EVENT_BUFFER_CAPACITY);
-  if (g_telemetryEventCount < TELEMETRY_EVENT_BUFFER_CAPACITY) {
+  g_telemetryEventHead = (uint16_t)((g_telemetryEventHead + 1U) % g_telemetryEventCapacity);
+  if (g_telemetryEventCount < g_telemetryEventCapacity) {
     g_telemetryEventCount++;
   }
 }
@@ -137,9 +233,9 @@ static void telemetryFillStatusLocked(TelemetryStatus* outStatus) {
   outStatus->oldestEventId = telemetryOldestEventIdLocked();
   outStatus->latestEventId = telemetryLatestEventIdLocked();
   outStatus->storedCount = g_telemetryCount;
-  outStatus->capacity = TELEMETRY_BUFFER_CAPACITY;
+  outStatus->capacity = g_telemetrySampleCapacity;
   outStatus->eventCount = g_telemetryEventCount;
-  outStatus->eventCapacity = TELEMETRY_EVENT_BUFFER_CAPACITY;
+  outStatus->eventCapacity = g_telemetryEventCapacity;
   outStatus->sampleRateMs = TELEMETRY_SAMPLE_INTERVAL_MS;
   outStatus->sessionStartCarIndex = g_telemetrySessionStartCarIndex;
   outStatus->loggingActive = g_telemetryLoggingActive;
@@ -164,30 +260,27 @@ bool telemetryStartLogging(const StoredVar_type* storedVar,
   uint32_t nowMs = millis();
   TelemetrySample* allocatedBuffer = g_telemetrySamples;
   TelemetryEvent* allocatedEventBuffer = g_telemetryEvents;
+  uint16_t allocatedSampleCapacity = g_telemetrySampleCapacity;
+  uint16_t allocatedEventCapacity = g_telemetryEventCapacity;
   if (allocatedBuffer == nullptr) {
-    allocatedBuffer = (TelemetrySample*)malloc(sizeof(TelemetrySample) * TELEMETRY_BUFFER_CAPACITY);
+    allocatedBuffer = telemetryAllocateSampleBuffer(&allocatedSampleCapacity);
     if (allocatedBuffer == nullptr) {
-      telemetrySetLastStartError("Telemetry start failed: out of memory");
+      telemetrySetLastStartError("Telemetry start failed: not enough free memory");
       return false;
     }
   }
   if (allocatedEventBuffer == nullptr) {
-    allocatedEventBuffer = (TelemetryEvent*)malloc(sizeof(TelemetryEvent) * TELEMETRY_EVENT_BUFFER_CAPACITY);
-    if (allocatedEventBuffer == nullptr) {
-      if (g_telemetrySamples == nullptr && allocatedBuffer != nullptr) {
-        free(allocatedBuffer);
-      }
-      telemetrySetLastStartError("Telemetry start failed: out of memory");
-      return false;
-    }
+    allocatedEventBuffer = telemetryAllocateEventBuffer(&allocatedEventCapacity);
   }
 
   portENTER_CRITICAL(&g_telemetryMux);
   if (g_telemetrySamples == nullptr) {
     g_telemetrySamples = allocatedBuffer;
+    g_telemetrySampleCapacity = allocatedSampleCapacity;
   }
   if (g_telemetryEvents == nullptr) {
     g_telemetryEvents = allocatedEventBuffer;
+    g_telemetryEventCapacity = allocatedEventCapacity;
   }
   bool shouldFreeTempBuffer = (allocatedBuffer != nullptr && g_telemetrySamples != allocatedBuffer);
   bool shouldFreeTempEventBuffer = (allocatedEventBuffer != nullptr && g_telemetryEvents != allocatedEventBuffer);
@@ -246,6 +339,8 @@ void telemetryClear() {
   eventBufferToFree = g_telemetryEvents;
   g_telemetrySamples = nullptr;
   g_telemetryEvents = nullptr;
+  g_telemetrySampleCapacity = 0U;
+  g_telemetryEventCapacity = 0U;
   g_telemetryHead = 0;
   g_telemetryCount = 0;
   g_telemetryEventHead = 0;
@@ -340,7 +435,7 @@ size_t telemetryCopySamplesAfter(uint32_t afterSeq,
       for (size_t i = 0; i < copied; i++) {
         uint32_t seq = firstSeq + (uint32_t)i;
         uint16_t offset = (uint16_t)(seq - oldestSeq);
-        uint16_t index = (uint16_t)((oldestIndex + offset) % TELEMETRY_BUFFER_CAPACITY);
+        uint16_t index = (uint16_t)((oldestIndex + offset) % g_telemetrySampleCapacity);
         outSamples[i] = g_telemetrySamples[index];
       }
 
@@ -371,17 +466,17 @@ size_t telemetryCopyEvents(TelemetryEvent* outEvents,
 
   telemetryFillStatusLocked(outStatus);
 
-  if (g_telemetryEventCount > 0 && outEvents != nullptr && maxEvents > 0) {
+  if (g_telemetryEventCount > 0 && g_telemetryEventCapacity > 0U && outEvents != nullptr && maxEvents > 0) {
     uint16_t oldestIndex = telemetryOldestEventIndexLocked();
     size_t available = g_telemetryEventCount;
     copied = (available < maxEvents) ? available : maxEvents;
     if (available > maxEvents) {
       truncated = true;
-      oldestIndex = (uint16_t)((oldestIndex + (available - maxEvents)) % TELEMETRY_EVENT_BUFFER_CAPACITY);
+      oldestIndex = (uint16_t)((oldestIndex + (available - maxEvents)) % g_telemetryEventCapacity);
     }
 
     for (size_t i = 0; i < copied; i++) {
-      uint16_t index = (uint16_t)((oldestIndex + i) % TELEMETRY_EVENT_BUFFER_CAPACITY);
+      uint16_t index = (uint16_t)((oldestIndex + i) % g_telemetryEventCapacity);
       outEvents[i] = g_telemetryEvents[index];
     }
   }
@@ -418,7 +513,7 @@ void telemetryCaptureSample(uint8_t carIndex,
     return;
   }
 
-  if (g_telemetrySamples == nullptr) {
+  if (g_telemetrySamples == nullptr || g_telemetrySampleCapacity == 0U) {
     g_telemetryLoggingActive = false;
     portEXIT_CRITICAL(&g_telemetryMux);
     return;
@@ -475,8 +570,8 @@ void telemetryCaptureSample(uint8_t carIndex,
   sample.flags = flags;
 
   g_telemetrySamples[g_telemetryHead] = sample;
-  g_telemetryHead = (uint16_t)((g_telemetryHead + 1U) % TELEMETRY_BUFFER_CAPACITY);
-  if (g_telemetryCount < TELEMETRY_BUFFER_CAPACITY) {
+  g_telemetryHead = (uint16_t)((g_telemetryHead + 1U) % g_telemetrySampleCapacity);
+  if (g_telemetryCount < g_telemetrySampleCapacity) {
     g_telemetryCount++;
   } else {
     g_telemetryWrapped = true;

--- a/source/ESPEED32/telemetry_logging.cpp
+++ b/source/ESPEED32/telemetry_logging.cpp
@@ -337,13 +337,9 @@ bool telemetryStartLogging(const StoredVar_type* storedVar,
 }
 
 const char* telemetryGetLastStartError() {
-  static thread_local char lastStartErrorSnapshot[sizeof(g_telemetryLastStartError)];
-  portENTER_CRITICAL(&g_telemetryMux);
-  strncpy(lastStartErrorSnapshot, g_telemetryLastStartError,
-          sizeof(lastStartErrorSnapshot) - 1U);
-  lastStartErrorSnapshot[sizeof(lastStartErrorSnapshot) - 1U] = '\0';
-  portEXIT_CRITICAL(&g_telemetryMux);
-  return lastStartErrorSnapshot;
+  static char snapshot[sizeof(g_telemetryLastStartError)];
+  telemetryCopyLastStartError(snapshot, sizeof(snapshot));
+  return snapshot;
 }
 
 void telemetryStopLogging() {

--- a/source/ESPEED32/telemetry_logging.cpp
+++ b/source/ESPEED32/telemetry_logging.cpp
@@ -27,10 +27,26 @@ static bool g_telemetryLastActiveCarValid = false;
 static CarParam_type g_telemetryLastActiveCar;
 static char g_telemetryLastStartError[64] = "";
 
+static void telemetryCopyLastStartError(char* out, size_t outLen) {
+  if (out == nullptr || outLen == 0U) {
+    return;
+  }
+
+  portENTER_CRITICAL(&g_telemetryMux);
+  strncpy(out, g_telemetryLastStartError, outLen - 1U);
+  out[outLen - 1U] = '\0';
+  portEXIT_CRITICAL(&g_telemetryMux);
+}
+
 static void telemetrySetLastStartError(const char* msg) {
+  char localError[sizeof(g_telemetryLastStartError)];
   if (msg == nullptr) msg = "";
-  strncpy(g_telemetryLastStartError, msg, sizeof(g_telemetryLastStartError) - 1U);
-  g_telemetryLastStartError[sizeof(g_telemetryLastStartError) - 1U] = '\0';
+  strncpy(localError, msg, sizeof(localError) - 1U);
+  localError[sizeof(localError) - 1U] = '\0';
+
+  portENTER_CRITICAL(&g_telemetryMux);
+  memcpy(g_telemetryLastStartError, localError, sizeof(g_telemetryLastStartError));
+  portEXIT_CRITICAL(&g_telemetryMux);
 }
 
 static uint16_t telemetryAlignCapacityDown(uint16_t value, uint16_t step, uint16_t minimum) {

--- a/source/ESPEED32/telemetry_logging.cpp
+++ b/source/ESPEED32/telemetry_logging.cpp
@@ -23,6 +23,13 @@ static uint8_t g_telemetrySessionStartCarIndex = 0;
 static uint8_t g_telemetryLastSelectedCarIndex = 0;
 static bool g_telemetryLastActiveCarValid = false;
 static CarParam_type g_telemetryLastActiveCar;
+static char g_telemetryLastStartError[64] = "";
+
+static void telemetrySetLastStartError(const char* msg) {
+  if (msg == nullptr) msg = "";
+  strncpy(g_telemetryLastStartError, msg, sizeof(g_telemetryLastStartError) - 1U);
+  g_telemetryLastStartError[sizeof(g_telemetryLastStartError) - 1U] = '\0';
+}
 
 static uint32_t telemetryOldestSeqLocked() {
   if (g_telemetryCount == 0 || g_telemetryNextSeq == 0) {
@@ -145,8 +152,13 @@ bool telemetryStartLogging(const StoredVar_type* storedVar,
                            uint16_t encoderInvertEnabled,
                            uint16_t adcVoltageRange_mV,
                            uint8_t activeCarIndex) {
-  if (storedVar == nullptr || activeCarIndex >= CAR_MAX_COUNT) {
+  telemetrySetLastStartError("");
+  if (storedVar == nullptr) {
+    telemetrySetLastStartError("Telemetry start failed: invalid config");
     return false;
+  }
+  if (activeCarIndex >= CAR_MAX_COUNT) {
+    activeCarIndex = (storedVar->selectedCarNumber < CAR_MAX_COUNT) ? (uint8_t)storedVar->selectedCarNumber : 0U;
   }
 
   uint32_t nowMs = millis();
@@ -155,6 +167,7 @@ bool telemetryStartLogging(const StoredVar_type* storedVar,
   if (allocatedBuffer == nullptr) {
     allocatedBuffer = (TelemetrySample*)malloc(sizeof(TelemetrySample) * TELEMETRY_BUFFER_CAPACITY);
     if (allocatedBuffer == nullptr) {
+      telemetrySetLastStartError("Telemetry start failed: out of memory");
       return false;
     }
   }
@@ -164,6 +177,7 @@ bool telemetryStartLogging(const StoredVar_type* storedVar,
       if (g_telemetrySamples == nullptr && allocatedBuffer != nullptr) {
         free(allocatedBuffer);
       }
+      telemetrySetLastStartError("Telemetry start failed: out of memory");
       return false;
     }
   }
@@ -211,6 +225,10 @@ bool telemetryStartLogging(const StoredVar_type* storedVar,
   }
 
   return true;
+}
+
+const char* telemetryGetLastStartError() {
+  return g_telemetryLastStartError;
 }
 
 void telemetryStopLogging() {

--- a/source/ESPEED32/telemetry_logging.cpp
+++ b/source/ESPEED32/telemetry_logging.cpp
@@ -321,7 +321,13 @@ bool telemetryStartLogging(const StoredVar_type* storedVar,
 }
 
 const char* telemetryGetLastStartError() {
-  return g_telemetryLastStartError;
+  static thread_local char lastStartErrorSnapshot[sizeof(g_telemetryLastStartError)];
+  portENTER_CRITICAL(&g_telemetryMux);
+  strncpy(lastStartErrorSnapshot, g_telemetryLastStartError,
+          sizeof(lastStartErrorSnapshot) - 1U);
+  lastStartErrorSnapshot[sizeof(lastStartErrorSnapshot) - 1U] = '\0';
+  portEXIT_CRITICAL(&g_telemetryMux);
+  return lastStartErrorSnapshot;
 }
 
 void telemetryStopLogging() {

--- a/source/ESPEED32/telemetry_logging.h
+++ b/source/ESPEED32/telemetry_logging.h
@@ -7,8 +7,14 @@
 #include "slot_ESC.h"
 
 #define TELEMETRY_SAMPLE_INTERVAL_MS 20U
-#define TELEMETRY_BUFFER_CAPACITY    3000U
-#define TELEMETRY_EVENT_BUFFER_CAPACITY 128U
+#define TELEMETRY_BUFFER_CAPACITY    3000U  /* Maximum sample capacity when enough heap is available */
+#define TELEMETRY_BUFFER_MIN_CAPACITY 512U /* Minimum useful sample capacity before start fails */
+#define TELEMETRY_BUFFER_ALLOC_STEP   128U /* Step-down size when adapting sample capacity to free heap */
+#define TELEMETRY_EVENT_BUFFER_CAPACITY 128U /* Maximum event capacity when enough heap is available */
+#define TELEMETRY_EVENT_BUFFER_MIN_CAPACITY 16U
+#define TELEMETRY_EVENT_BUFFER_ALLOC_STEP 16U
+#define TELEMETRY_HEAP_RESERVE_BYTES  49152U /* Keep headroom for WiFi/web/OTA while telemetry is active */
+#define TELEMETRY_HEAP_MIN_RESERVE_BYTES 32768U
 
 #define TELEMETRY_FLAG_BRAKE_BUTTON      0x01U
 #define TELEMETRY_FLAG_TRIGGER_RELEASING 0x02U

--- a/source/ESPEED32/telemetry_logging.h
+++ b/source/ESPEED32/telemetry_logging.h
@@ -88,6 +88,7 @@ bool telemetryStartLogging(const StoredVar_type* storedVar,
                            uint16_t encoderInvertEnabled,
                            uint16_t adcVoltageRange_mV,
                            uint8_t activeCarIndex);
+const char* telemetryGetLastStartError();
 void telemetryStopLogging();
 void telemetryClear();
 bool telemetryIsLoggingActive();

--- a/source/ESPEED32/telemetry_logging.h
+++ b/source/ESPEED32/telemetry_logging.h
@@ -10,11 +10,11 @@
 #define TELEMETRY_BUFFER_CAPACITY    3000U  /* Maximum sample capacity when enough heap is available */
 #define TELEMETRY_BUFFER_MIN_CAPACITY 512U /* Minimum useful sample capacity before start fails */
 #define TELEMETRY_BUFFER_ALLOC_STEP   128U /* Step-down size when adapting sample capacity to free heap */
-#define TELEMETRY_EVENT_BUFFER_CAPACITY 128U /* Maximum event capacity when enough heap is available */
+#define TELEMETRY_EVENT_BUFFER_CAPACITY 64U /* Maximum event capacity when enough heap is available */
 #define TELEMETRY_EVENT_BUFFER_MIN_CAPACITY 16U
 #define TELEMETRY_EVENT_BUFFER_ALLOC_STEP 16U
-#define TELEMETRY_HEAP_RESERVE_BYTES  49152U /* Keep headroom for WiFi/web/OTA while telemetry is active */
-#define TELEMETRY_HEAP_MIN_RESERVE_BYTES 32768U
+#define TELEMETRY_HEAP_RESERVE_BYTES  65536U /* Keep headroom for WiFi/web/OTA while telemetry is active */
+#define TELEMETRY_HEAP_MIN_RESERVE_BYTES 49152U
 
 #define TELEMETRY_FLAG_BRAKE_BUTTON      0x01U
 #define TELEMETRY_FLAG_TRIGGER_RELEASING 0x02U


### PR DESCRIPTION
## Summary

Brings together the full `v6.11` branch work: hardened telemetry live streaming, a more robust WiFi portal start/stop cycle, a dedicated FreeRTOS task for web serving, and polished OTA and telemetry UX.

## Changes

### Features
- Added `/api/telemetry/config` endpoint for WiFi clients to fetch telemetry configuration
- Added `/api/telemetry/events` endpoint and `TEVENTS` serial command — dedicated path for full event history during export, separate from the lightweight live polling payload
- Added `WiFiTask` (FreeRTOS, same priority as Task1, Core 0) so `handleClient()` runs in its own task and yields via `vTaskDelay(1)` instead of blocking the encoder or OLED in Task1
- Added adaptive heap-aware telemetry buffer allocation with step-down fallback
- Added `portMUX_TYPE` spinlock for safe cross-core telemetry buffer access
- Exposed `telemetryGetLastStartError()` so start failures are reported in HTTP and serial responses

### Fixes
- Capped live HTTP telemetry at 16 samples per response (~2 KB) — eliminates both the lwIP TX queue overflow from 90+ tiny fragments and the heap crash from allocating a single large response on fragmented heap
- Restored USB serial live limit to 96 samples, separate from the HTTP limit of 16
- Added deferred WiFi stop via `g_wifiStopPending` / `g_wifiRestartAfterStopPending` flags and `stopWiFiPortalNow()` with a 50 ms lwIP drain — fixes browser losing connection mid-request during shutdown
- Added clean AP init sequence (`WiFi.persistent(false)` + `disconnect` + 120 ms delay) and half-torn-down state recovery in `startWiFiPortal()` — fixes having to reboot the controller to reconnect the browser
- Fixed telemetry logging not being stopped when `g_wifiServer` was already null at stop time
- Fixed `thread_local` in `telemetryGetLastStartError` — `thread_local` is unsupported on FreeRTOS and would crash the controller when telemetry start fails
- Changed OTA busy button text from "Another update is already running. Wait for completion." to "Firmware update in progress — please wait." — reads as status, not a failure
- Changed OLED OTA label from "OTA Update" to "FW Update" to fit the display

### UI
- Tail-only initial telemetry load (last 64 samples via status → `afterSeq`) — avoids fetching the full buffer on connect
- `AbortController` fetch tracking moved to a `Set` so all in-flight requests are reliably cancelled during OTA or pagehide
- 10 s timeout on all WiFi telemetry fetches via `AbortController`
- Telemetry polling paused after errors; resumes on explicit refresh rather than hammering the controller
- WiFi poll interval minimum raised to 1 000 ms
- Telemetry paused before config backup download in OTA modal, not just before the upload — prevents the backup fetch from being blocked by active telemetry
- `pauseBackgroundActivityForOta` stops telemetry logging via TSTOP before OTA starts
- Telemetry export fetches full event history via dedicated events transport and builds the download blob client-side
- RFC1918 private IPs (`10.x`, `192.168.x`, `172.16–31.x`) recognised as device host in `public.html` — eliminates the 50/50 race on the `/api/info` timeout that caused the wrong panel link to appear
- Chat widget passes conversation context to backend

## Verification

- [x] `./scripts/flash_all.sh --compile-only`
- [x] Encoder and OLED respond immediately while browser is loading the UI
- [x] Telemetry graph populates and live traces appear without "Load failed" or device reboot
- [x] WiFi portal can be stopped and restarted without rebooting the controller
- [x] OTA update completes; busy message reads correctly throughout
- [x] "Open Controller Panel" link shows consistently on device IP
- [x] Verified fixes for #37, #38, #39

Closes #37
Closes #38
Closes #39